### PR TITLE
improve factory for performance

### DIFF
--- a/include/inria_wbc/behaviors/factory.hpp
+++ b/include/inria_wbc/behaviors/factory.hpp
@@ -20,34 +20,48 @@ namespace inria_wbc
             typedef std::shared_ptr<Behavior> behavior_ptr_t;
             typedef std::function<behavior_ptr_t(const inria_wbc::controllers::TalosBaseController::Params &)>
                 behavior_creator_t;
+            typedef inria_wbc::controllers::TalosBaseController::Params behavior_params_t;
 
             void register_behavior(const std::string &behavior_name, behavior_creator_t pfn_create_behavior)
             {
                 if (behavior_map_.find(behavior_name) == behavior_map_.end())
                 {
-                    behavior_map_[behavior_name] = std::make_pair(pfn_create_behavior, std::shared_ptr<Behavior>());
+                    BehaviorInfo info = {.creator_function = pfn_create_behavior};
+                    behavior_map_[behavior_name] = info;
                 }
                 else
                 {
                     std::cout << "Warning : there is already a " << behavior_name << " behavior in the factory" << std::endl;
                 }
             }
-            
-            behavior_ptr_t create(const std::string &behavior_name, const controllers::TalosBaseController::Params& params = controllers::TalosBaseController::Params())
+            // standard creation : one new object each time
+            behavior_ptr_t create(const std::string &behavior_name, const behavior_params_t& params)
+            {
+                auto it = behavior_map_.find(behavior_name);
+                if(it != behavior_map_.end())
+                {
+                    auto behavior = it->second.creator_function(params);
+                    it->second.params = params;
+                    it->second.prototype = behavior->clone();
+                    return behavior;
+                }
+                else
+                    std::cerr << "Error :  " << behavior_name << " is not in the behavior factory" << std::endl;
+                return behavior_ptr_t();
+            }
+
+            // when you create many identical objects:
+            // first call, create the object like create()
+            // second time, return a (clean, reset) clone to avoid parsing costs
+            // WARNING: the params are ignored the second time!
+            behavior_ptr_t create_or_clone(const std::string &behavior_name, const behavior_params_t& params=behavior_params_t())
             {
                 // std::optional is c++17 only, this is why we use boost for now
                 auto it = behavior_map_.find(behavior_name);
-                if (it != behavior_map_.end() && it->second.second)
-                {
-                    // WARNING: params are ignored for the 2nd object!
-                    return it->second.second->clone();
-                }
+                if (it != behavior_map_.end() && it->second.prototype)
+                    return it->second.prototype->clone();
                 else if(it != behavior_map_.end())
-                {
-                    auto behavior = it->second.first(params);
-                    it->second.second = behavior->clone();
-                    return behavior;
-                }
+                   return create(behavior_name, params);
                 else
                     std::cerr << "Error :  " << behavior_name << " is not in the behavior factory" << std::endl;
                 return behavior_ptr_t();
@@ -62,9 +76,14 @@ namespace inria_wbc
             }
 
         private:
+            struct BehaviorInfo {
+                behavior_creator_t creator_function;
+                behavior_ptr_t prototype;
+                behavior_params_t params;
+            };
             Factory() {}
             Factory &operator=(const Factory &) { return *this; }
-            std::map<std::string, std::pair<behavior_creator_t, std::shared_ptr<Behavior>>> behavior_map_;
+            std::map<std::string, BehaviorInfo> behavior_map_;
         };
         
         template <typename BehaviorClass>

--- a/include/inria_wbc/behaviors/factory.hpp
+++ b/include/inria_wbc/behaviors/factory.hpp
@@ -45,7 +45,7 @@ namespace inria_wbc
                 else if(it != behavior_map_.end())
                 {
                     auto behavior = it->second.first(params);
-                    it->second.second = behavior;
+                    it->second.second = behavior->clone();
                     return behavior;
                 }
                 else

--- a/include/inria_wbc/behaviors/factory.hpp
+++ b/include/inria_wbc/behaviors/factory.hpp
@@ -1,7 +1,6 @@
 #ifndef IWBC_FACTORY_HPP
 #define IWBC_FACTORY_HPP
 
-
 #include <inria_wbc/behaviors/behavior.hpp>
 
 namespace inria_wbc
@@ -26,20 +25,29 @@ namespace inria_wbc
             {
                 if (behavior_map_.find(behavior_name) == behavior_map_.end())
                 {
-                    behavior_map_[behavior_name] = pfn_create_behavior;
+                    behavior_map_[behavior_name] = std::make_pair(pfn_create_behavior, std::shared_ptr<Behavior>());
                 }
                 else
                 {
                     std::cout << "Warning : there is already a " << behavior_name << " behavior in the factory" << std::endl;
                 }
             }
-
-            behavior_ptr_t create(const std::string &behavior_name,
-                                         const inria_wbc::controllers::TalosBaseController::Params &params)
+            
+            behavior_ptr_t create(const std::string &behavior_name, const controllers::TalosBaseController::Params& params = controllers::TalosBaseController::Params())
             {
+                // std::optional is c++17 only, this is why we use boost for now
                 auto it = behavior_map_.find(behavior_name);
-                if (it != behavior_map_.end())
-                    return it->second(params);
+                if (it != behavior_map_.end() && it->second.second)
+                {
+                    // WARNING: params are ignored for the 2nd object!
+                    return it->second.second->clone();
+                }
+                else if(it != behavior_map_.end())
+                {
+                    auto behavior = it->second.first(params);
+                    it->second.second = behavior;
+                    return behavior;
+                }
                 else
                     std::cerr << "Error :  " << behavior_name << " is not in the behavior factory" << std::endl;
                 return behavior_ptr_t();
@@ -56,7 +64,7 @@ namespace inria_wbc
         private:
             Factory() {}
             Factory &operator=(const Factory &) { return *this; }
-            std::map<std::string, behavior_creator_t> behavior_map_;
+            std::map<std::string, std::pair<behavior_creator_t, std::shared_ptr<Behavior>>> behavior_map_;
         };
         
         template <typename BehaviorClass>

--- a/include/inria_wbc/behaviors/talos_move_arm.hpp
+++ b/include/inria_wbc/behaviors/talos_move_arm.hpp
@@ -17,7 +17,12 @@ namespace inria_wbc
         public:
             TalosMoveArm(const inria_wbc::controllers::TalosBaseController::Params &params);
             TalosMoveArm() = delete;
-            TalosMoveArm(const TalosMoveArm &other) = default;
+            TalosMoveArm(const TalosMoveArm &other) : Behavior(other) {
+                trajectories_ = other.trajectories_;
+                current_trajectory_ = other.current_trajectory_;
+                trajectory_duration_ = other.trajectory_duration_;
+                motion_size_ = other.motion_size_;
+            };
             virtual std::shared_ptr<Behavior> clone() override { return std::make_shared<TalosMoveArm>(*this); }
             bool update() override;
             virtual ~TalosMoveArm() {}

--- a/include/inria_wbc/behaviors/talos_squat.hpp
+++ b/include/inria_wbc/behaviors/talos_squat.hpp
@@ -16,7 +16,12 @@ namespace inria_wbc
         public:
             TalosSquat(const inria_wbc::controllers::TalosBaseController::Params &params);
             TalosSquat() = delete;
-            TalosSquat(const TalosSquat &other) = default;
+            TalosSquat(const TalosSquat &other) : Behavior(other) {
+                trajectories_ = other.trajectories_;
+                current_trajectory_ = other.current_trajectory_;
+                trajectory_duration_ = other.trajectory_duration_;
+                motion_size_ = other.motion_size_;
+            }
             virtual std::shared_ptr<Behavior> clone() override { return std::make_shared<TalosSquat>(*this); }
             bool update() override;
             virtual ~TalosSquat() {}

--- a/src/controllers/talos_base_controller.cpp
+++ b/src/controllers/talos_base_controller.cpp
@@ -37,6 +37,7 @@
 #include <tsid/robots/robot-wrapper.hpp>
 
 #include "inria_wbc/controllers/talos_base_controller.hpp"
+#include <chrono>
 
 using namespace tsid;
 using namespace tsid::trajectories;
@@ -80,6 +81,7 @@ namespace inria_wbc
       assert(other.t_ == 0);
       params_ = other.params_;
       fb_joint_name_ = other.fb_joint_name_;
+      verbose_ = params_.verbose;
 
       robot_ = std::make_shared<RobotWrapper>(other.robot_->model(), params_.verbose);
       assert(robot_->model() == other.robot_->model());
@@ -109,6 +111,8 @@ namespace inria_wbc
       dq_.resize(ndofs);
       ddq_.resize(ndofs);
       tau_.resize(ndofs);
+
+      //q0_ is set with the stack from q_tsid
       q_.setZero(q_.size());
       dq_.setZero(dq_.size());
       ddq_.setZero(ddq_.size());

--- a/src/controllers/talos_pos_tracking.cpp
+++ b/src/controllers/talos_pos_tracking.cpp
@@ -59,7 +59,6 @@ namespace inria_wbc
     
     TalosPosTracking::TalosPosTracking(const TalosPosTracking& other) : TalosBaseController(other)
     {
-      std::cout<<"copy TalosPosTracking"<<std::endl;
       // copy the parameters
       w_com_ = other.w_com_;
       w_posture_ = other.w_posture_;
@@ -68,7 +67,7 @@ namespace inria_wbc
       w_floatingb_ = other.w_floatingb_;
       w_velocity_ = other.w_velocity_;
       w_rh_ = other.w_rh_;
-      w_rh_ = other.w_rh_;
+      w_lh_ = other.w_lh_;
       w_rf_ = other.w_rf_;
       w_lf_ = other.w_lf_;
       kp_contact_ = other.kp_contact_;
@@ -77,13 +76,13 @@ namespace inria_wbc
       kp_floatingb_ = other.kp_floatingb_;
       kp_rh_ = other.kp_rh_;
       kp_lh_ = other.kp_lh_;
-      kp_lh_ = other.kp_lh_;
       kp_rf_ = other.kp_rf_;
       kp_lf_ = other.kp_lf_;
 
       // initialize everything
       set_stack_configuration();
       init_references();
+     
     }
 
     void TalosPosTracking::parse_configuration_yaml(const std::string &sot_config_path)
@@ -131,7 +130,6 @@ namespace inria_wbc
       Eigen::Quaterniond quat(q_tsid_(6), q_tsid_(3), q_tsid_(4), q_tsid_(5));
       Eigen::AngleAxisd aaxis(quat);
       q0_ << q_tsid_.head(3), aaxis.angle() * aaxis.axis(), q_tsid_.tail(robot_->na()); //q_tsid_ is of size 37 (pos+quat+nactuated)
-
       //Quaternion quat = {.w = q_tsid_(6), .x = q_tsid_(3), .y = q_tsid_(4), .z = q_tsid_(5)}; //convert quaternion to euler for dart
 
       //EulerAngles euler = to_euler(quat);
@@ -246,7 +244,7 @@ namespace inria_wbc
       ////////// Add the position, velocity and acceleration limits
       bounds_task_ = std::make_shared<TaskJointPosVelAccBounds>("task-posVelAcc-bounds", *robot_, dt_, verbose_);
       dq_max_ = robot_->model().velocityLimit.tail(robot_->na());
-      ddq_max_ = dq_max_ / dt_;
+      ddq_max_ = dq_max_ / dt_;      
       bounds_task_->setVelocityBounds(dq_max_);
       bounds_task_->setAccelerationBounds(ddq_max_);
       q_lb_ = robot_->model().lowerPositionLimit.tail(robot_->na());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,9 @@ find_package(Boost COMPONENTS unit_test_framework)
 enable_testing()
 set(BINARY ${CMAKE_PROJECT_NAME}_test)
 
-
+# the tests require Dart to run (for now?)
 if(${COMPILE_ROBOT_DART_EXAMPLE} STREQUAL "ON")
-        set(TEST_SOURCES test_clone.cpp)
+        set(TEST_SOURCES test_clone.cpp test_factory.cpp)
 endif()
 
 foreach(TEST ${TEST_SOURCES})

--- a/tests/test_behavior.hpp
+++ b/tests/test_behavior.hpp
@@ -1,12 +1,11 @@
 #ifndef TEST_BEHAVIOR_HPP_
-#define  TEST_BEHAVIOR_HPP_
+#define TEST_BEHAVIOR_HPP_
 
 #include <vector>
 #include <map>
 
-
 std::pair<std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>> inline test_behavior(
-    const std::shared_ptr<inria_wbc::behaviors::Behavior>& behavior)
+    const std::shared_ptr<inria_wbc::behaviors::Behavior> &behavior)
 {
     std::cout << "running...";
     std::cout.flush();
@@ -18,10 +17,13 @@ std::pair<std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>> inline tes
 
     std::vector<Eigen::VectorXd> cmds, cmds_filtered;
     bool is_valid = false;
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 100; ++i)
+    {
+        std::cout << i << " ";
+        std::cout.flush();
         is_valid = behavior->update();
         auto cmd = controller->q(false);
-        if(is_valid)
+        if (is_valid)
         {
             cmds.push_back(cmd);
             cmds_filtered.push_back(controller->filter_cmd(cmd).tail(ncontrollable));
@@ -31,13 +33,19 @@ std::pair<std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>> inline tes
     return std::make_pair(cmds, cmds_filtered);
 }
 
-template <typename T> inline void compare_cmds(const T& cmds, const T& cmds2)
+template <typename T>
+inline void compare_cmds(const T &cmds, const T &cmds2)
 {
+    std::cout << "Comparing commands:";
     BOOST_CHECK_EQUAL(cmds.first.size(), cmds2.first.size());
-    for (int i = 0; i < cmds.first.size(); ++i) {
+    for (int i = 0; i < cmds.first.size(); ++i)
+    {
+        std::cout << i << " ";
+        std::cout.flush();
         BOOST_CHECK(cmds.first[i].isApprox(cmds2.first[i], 1e-8));
         BOOST_CHECK(cmds.second[i].isApprox(cmds2.second[i], 1e-8));
     }
+    std::cout << "done" << std::endl;
 }
 
 #endif

--- a/tests/test_behavior.hpp
+++ b/tests/test_behavior.hpp
@@ -1,0 +1,43 @@
+#ifndef TEST_BEHAVIOR_HPP_
+#define  TEST_BEHAVIOR_HPP_
+
+#include <vector>
+#include <map>
+
+
+std::pair<std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>> inline test_behavior(
+    const std::shared_ptr<inria_wbc::behaviors::Behavior>& behavior)
+{
+    std::cout << "running...";
+    std::cout.flush();
+    auto controller = behavior->controller();
+
+    auto all_dofs = controller->all_dofs();
+    auto controllable_dofs = controller->controllable_dofs();
+    uint ncontrollable = controllable_dofs.size();
+
+    std::vector<Eigen::VectorXd> cmds, cmds_filtered;
+    bool is_valid = false;
+    for (int i = 0; i < 3; ++i) {
+        is_valid = behavior->update();
+        auto cmd = controller->q(false);
+        if(is_valid)
+        {
+            cmds.push_back(cmd);
+            cmds_filtered.push_back(controller->filter_cmd(cmd).tail(ncontrollable));
+        }
+    }
+    std::cout << "done" << std::endl;
+    return std::make_pair(cmds, cmds_filtered);
+}
+
+template <typename T> inline void compare_cmds(const T& cmds, const T& cmds2)
+{
+    BOOST_CHECK_EQUAL(cmds.first.size(), cmds2.first.size());
+    for (int i = 0; i < cmds.first.size(); ++i) {
+        BOOST_CHECK(cmds.first[i].isApprox(cmds2.first[i], 1e-8));
+        BOOST_CHECK(cmds.second[i].isApprox(cmds2.second[i], 1e-8));
+    }
+}
+
+#endif

--- a/tests/test_clone.cpp
+++ b/tests/test_clone.cpp
@@ -12,29 +12,31 @@ BOOST_AUTO_TEST_CASE(clone_test)
 {
     srand(time(0));
     auto behaviors = {"../etc/squat.yaml", "../etc/arm.yaml"};
-    std::vector<std::pair<std::string, std::string>> packages
-        = {{"talos_description", "talos/talos_description"}};
+    std::vector<std::pair<std::string, std::string>> packages = {{"talos_description", "talos/talos_description"}};
     auto robot = std::make_shared<robot_dart::Robot>("talos/talos.urdf", packages);
 
     std::cout << "robot:" << robot->model_filename() << std::endl;
 
-    for (auto& sot_config_path : behaviors) {
+    for (auto &sot_config_path : behaviors)
+    {
         std::cout << "configuration:" << sot_config_path << std::endl;
 
-        inria_wbc::controllers::TalosBaseController::Params params
-            = {robot->model_filename(), "../etc/talos_configurations.srdf", sot_config_path, "",
-                0.001, false, robot->mimic_dof_names()};
+        inria_wbc::controllers::TalosBaseController::Params params = {robot->model_filename(), "../etc/talos_configurations.srdf", sot_config_path, "",
+                                                                      0.001, false, robot->mimic_dof_names()};
 
         std::string behavior_name;
         auto config = YAML::LoadFile(sot_config_path);
         inria_wbc::utils::parse(behavior_name, "name", config, false, "BEHAVIOR");
 
-        auto behavior = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
-        auto behavior2 = behavior->clone();
-
-        auto cmds = test_behavior(behavior);
-        auto cmds2 = test_behavior(behavior2);
-    
-        compare_cmds(cmds, cmds2);
+        for (size_t i = 0; i < 10; ++i)
+        {
+            std::cout<<"Clone #"<<i<<" for " << sot_config_path << std::endl;
+            auto behavior = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
+            auto behavior2 = behavior->clone();
+            auto cmds = test_behavior(behavior);
+            behavior.reset();// we clean to trigger a potential segv if there is some shared data
+            auto cmds2 = test_behavior(behavior2);
+            compare_cmds(cmds, cmds2);            
+        }
     }
 }

--- a/tests/test_factory.cpp
+++ b/tests/test_factory.cpp
@@ -31,11 +31,13 @@ BOOST_AUTO_TEST_CASE(factory_test)
 
         auto behavior = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
         auto behavior2 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
-        auto behavior3 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
 
 
         auto cmds = test_behavior(behavior);
         auto cmds2 = test_behavior(behavior2);
+
+        auto behavior3 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
+
         auto cmds3 = test_behavior(behavior3);
 
         compare_cmds(cmds, cmds2);

--- a/tests/test_factory.cpp
+++ b/tests/test_factory.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <robot_dart/robot.hpp>
 #include <vector>
+#include <chrono>
 
 #include "test_behavior.hpp"
 
@@ -12,35 +13,49 @@ BOOST_AUTO_TEST_CASE(factory_test)
 {
     srand(time(0));
     auto behaviors = {"../etc/squat.yaml", "../etc/arm.yaml"};
-    std::vector<std::pair<std::string, std::string>> packages
-        = {{"talos_description", "talos/talos_description"}};
+    std::vector<std::pair<std::string, std::string>> packages = {{"talos_description", "talos/talos_description"}};
     auto robot = std::make_shared<robot_dart::Robot>("talos/talos.urdf", packages);
 
     std::cout << "robot:" << robot->model_filename() << std::endl;
 
-    for (auto& sot_config_path : behaviors) {
+    for (auto &sot_config_path : behaviors)
+    {
         std::cout << "configuration:" << sot_config_path << std::endl;
 
-        inria_wbc::controllers::TalosBaseController::Params params
-            = {robot->model_filename(), "../etc/talos_configurations.srdf", sot_config_path, "",
-                0.001, false, robot->mimic_dof_names()};
+        inria_wbc::controllers::TalosBaseController::Params params = {robot->model_filename(), "../etc/talos_configurations.srdf", sot_config_path, "",
+                                                                      0.001, false, robot->mimic_dof_names()};
 
         std::string behavior_name;
         auto config = YAML::LoadFile(sot_config_path);
         inria_wbc::utils::parse(behavior_name, "name", config, false, "BEHAVIOR");
 
+        // for reference
+        auto t1_base = std::chrono::high_resolution_clock::now();
         auto behavior = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
-        auto behavior2 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
+        auto t2_base = std::chrono::high_resolution_clock::now();
+        std::cout << "Standard creation:" << std::chrono::duration_cast<std::chrono::microseconds>(t2_base - t1_base).count() / 1000.0 << " ms" << std::endl;
 
+        // with clone system
+        auto t1 = std::chrono::high_resolution_clock::now();
+        auto behavior1 = inria_wbc::behaviors::Factory::instance().create_or_clone(behavior_name, params);
+        auto t2 = std::chrono::high_resolution_clock::now();
+        std::cout << "First clone creation:" << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() / 1000.0 << " ms" << std::endl;
 
-        auto cmds = test_behavior(behavior);
+        auto t3 = std::chrono::high_resolution_clock::now();
+        auto behavior2 = inria_wbc::behaviors::Factory::instance().create_or_clone(behavior_name, params);
+        auto t4 = std::chrono::high_resolution_clock::now();
+        std::cout << "Clone creation:" << std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3).count() / 1000.0 << " ms" << std::endl;
+
+        auto cmds_base = test_behavior(behavior);
+        auto cmds1 = test_behavior(behavior1);        
         auto cmds2 = test_behavior(behavior2);
 
-        auto behavior3 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
-
+        auto behavior3 = inria_wbc::behaviors::Factory::instance().create_or_clone(behavior_name, params);
         auto cmds3 = test_behavior(behavior3);
 
-        compare_cmds(cmds, cmds2);
-        compare_cmds(cmds, cmds2);
+        compare_cmds(cmds_base, cmds1);
+        compare_cmds(cmds_base, cmds2);
+        compare_cmds(cmds_base, cmds3);
+        
     }
 }

--- a/tests/test_factory.cpp
+++ b/tests/test_factory.cpp
@@ -8,7 +8,7 @@
 
 #include "test_behavior.hpp"
 
-BOOST_AUTO_TEST_CASE(clone_test)
+BOOST_AUTO_TEST_CASE(factory_test)
 {
     srand(time(0));
     auto behaviors = {"../etc/squat.yaml", "../etc/arm.yaml"};
@@ -30,11 +30,15 @@ BOOST_AUTO_TEST_CASE(clone_test)
         inria_wbc::utils::parse(behavior_name, "name", config, false, "BEHAVIOR");
 
         auto behavior = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
-        auto behavior2 = behavior->clone();
+        auto behavior2 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
+        auto behavior3 = inria_wbc::behaviors::Factory::instance().create(behavior_name, params);
+
 
         auto cmds = test_behavior(behavior);
         auto cmds2 = test_behavior(behavior2);
-    
+        auto cmds3 = test_behavior(behavior3);
+
+        compare_cmds(cmds, cmds2);
         compare_cmds(cmds, cmds2);
     }
 }


### PR DESCRIPTION
Improve the factory so that:
- the first time we ask for a behavior, we create it
- after this, we return clones of this first behavior to avoid re-parsing URDF files, etc.

WARNING: the params() are ignored for the second creation. I do not know yet how to trigger a proper warning here.

