### PR TITLE
fixe q and dq integration in Controller::_solve when using closed_loop

### DIFF
--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -160,8 +160,8 @@ namespace inria_wbc {
                 const Vector& dv = tsid_->getAccelerations(sol);
                 tau_tsid_ = tau;
                 a_tsid_ = dv;
-                v_tsid_ += dt_ * dv;
-                q_tsid_ = pinocchio::integrate(robot_->model(), q_tsid_, dt_ * v_tsid_);
+                v_tsid_ = dq + dt_ * dv;
+                q_tsid_ = pinocchio::integrate(robot_->model(), q, dt_ * v_tsid_);
                 t_ += dt_;
 
                 activated_contacts_forces_.clear();


### PR DESCRIPTION
There was an error in controller.cpp in the function Controller::_solve(const Eigen::VectorXd& q, const Eigen::VectorXd& dq). q and dq were not used to update v_tsid_ and q_tsid_. 
Before: 
                v_tsid_ += dt_ * dv;
                q_tsid_ = pinocchio::integrate(robot_->model(), q_tsid_, dt_ * v_tsid_);
After correction:
                v_tsid_ = dq + dt_ * dv;
                q_tsid_ = pinocchio::integrate(robot_->model(), q, dt_ * v_tsid_);