### PR TITLE
add support for customize_task_weights in behaviors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(INRIA_WBC_SOURCES
                             src/controllers/talos_pos_tracker.cpp
                             src/trajs/saver.cpp
                             src/trajs/loader.cpp
+                            src/behaviors/behavior.cpp
                             src/behaviors/generic/cartesian.cpp
                             src/behaviors/generic/cartesian_traj.cpp
                             src/behaviors/humanoid/squat.cpp

--- a/include/inria_wbc/behaviors/behavior.hpp
+++ b/include/inria_wbc/behaviors/behavior.hpp
@@ -10,8 +10,10 @@ namespace inria_wbc {
         public:
             using controller_ptr_t = std::shared_ptr<inria_wbc::controllers::Controller>;
             Behavior(const controller_ptr_t& controller, const YAML::Node& config) : 
-                controller_(controller)
-                { IWBC_ASSERT(controller, "Invalid controller pointer"); };
+                controller_(controller) { 
+                    IWBC_ASSERT(controller, "Invalid controller pointer"); 
+                    _customize_tasks(controller, config);
+                };
             virtual ~Behavior() {}
             virtual void update(const controllers::SensorData& sensor_data = {}) = 0;
             virtual std::shared_ptr<controllers::Controller> controller() { return controller_; };
@@ -19,6 +21,7 @@ namespace inria_wbc {
             virtual std::string behavior_type() const = 0;
 
         protected:
+            void _customize_tasks(const controller_ptr_t& controller, const YAML::Node& config);
             std::shared_ptr<inria_wbc::controllers::Controller> controller_;
             std::string behavior_type_;
         };

--- a/include/inria_wbc/controllers/pos_tracker.hpp
+++ b/include/inria_wbc/controllers/pos_tracker.hpp
@@ -60,7 +60,7 @@ namespace inria_wbc {
             // this only removes the task from the TSID list of tasks (the task is not destroyed)
             // therefore you can re-add it later by using its name
             void remove_task(const std::string& task_name, double transition_duration = 0.0);
-
+            void set_task_weight(const std::string& task_name, double w) { tsid_->updateTaskWeight(task_name, w); }
             // for external optimizers: we exclude the bound task for safety
             size_t num_task_weights() const;
             void update_task_weights(const std::vector<double>& new_weights);

--- a/src/behaviors/behavior.cpp
+++ b/src/behaviors/behavior.cpp
@@ -1,0 +1,24 @@
+#include <inria_wbc/behaviors/behavior.hpp>
+#include <inria_wbc/controllers/pos_tracker.hpp>
+#include <inria_wbc/controllers/tasks.hpp>
+
+namespace inria_wbc {
+    namespace behaviors {
+        void Behavior::_customize_tasks(const controller_ptr_t& controller, const YAML::Node& config)
+        {
+            static const std::string yellow = "\x1B[33m";
+            static const std::string rst = "\x1B[0m";
+            auto node = config["BEHAVIOR"];
+            if (node["customize_task_weights"]) {
+                auto pos_tracker = std::dynamic_pointer_cast<controllers::PosTracker>(controller);
+                IWBC_ASSERT(pos_tracker, "Task customization requires a controllers::PosTracker or a derivative");
+                auto tasks = node["customize_task_weights"];
+                for (auto it = tasks.begin(); it != tasks.end(); ++it) {
+                    auto name = IWBC_CHECK(it->first.as<std::string>());
+                    std::cout << yellow << "Warning:"  << " overriding weight of task: " << name << rst << std::endl;
+                    pos_tracker->set_task_weight(name, it->second.as<double>());
+                }
+            }
+        }
+    } // namespace behaviors
+} // namespace inria_wbc

--- a/src/behaviors/behavior.cpp
+++ b/src/behaviors/behavior.cpp
@@ -1,6 +1,6 @@
-#include <inria_wbc/behaviors/behavior.hpp>
-#include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/controllers/tasks.hpp>
+#include "inria_wbc/behaviors/behavior.hpp"
+#include "inria_wbc/controllers/pos_tracker.hpp"
+#include "inria_wbc/controllers/tasks.hpp"
 
 namespace inria_wbc {
     namespace behaviors {


### PR DESCRIPTION
Now in the YAML of the behavior, you can add `customize_task_weights:` and tune the weights. The rationale is that we sometimes want to deactivate some tasks in some behaviors (e.g. momentum in walk-on-spot).

Example:

```yaml
BEHAVIOR:
  name : humanoid::clapping
  trajectory_duration : 1.0
  motion_size : 1.1
  customize_task_weights:
    com: 0.0
```

Do not abuse it!

It is difficult to customize more that the weights in a generic way: 
- the size of masks depends on the task type
- the Kp are only for some tasks (e.g. SE3) and there is no generic interface

So, I'm not sure the added complexity / ugliness is worth it for the other parameters.