### PR TITLE
change access to deprecated tsid::sample pos, vel acc with setter/getter methods

### DIFF
--- a/example_project/include/tsid/tasks/ex_task.hpp
+++ b/example_project/include/tsid/tasks/ex_task.hpp
@@ -56,11 +56,33 @@ namespace tsid {
             const ConstraintBase& getConstraint() const;
 
             void setReference(TrajectorySample& ref);
+            void setReference(const SE3& ref);
             const TrajectorySample& getReference() const;
+
+            /** Return the desired task acceleration (after applying the specified mask).
+       *  The value is expressed in local frame is the local_frame flag is true,
+       *  otherwise it is expressed in a local world-oriented frame.
+      */
             const Vector& getDesiredAcceleration() const;
+
+            /** Return the task acceleration (after applying the specified mask).
+       *  The value is expressed in local frame is the local_frame flag is true,
+       *  otherwise it is expressed in a local world-oriented frame.
+      */
             Vector getAcceleration(ConstRefVector dv) const;
+
             virtual void setMask(math::ConstRefVector mask);
+
+            /** Return the position tracking error (after applying the specified mask).
+       *  The error is expressed in local frame is the local_frame flag is true,
+       *  otherwise it is expressed in a local world-oriented frame.
+      */
             const Vector& position_error() const;
+
+            /** Return the velocity tracking error (after applying the specified mask).
+       *  The error is expressed in local frame is the local_frame flag is true,
+       *  otherwise it is expressed in a local world-oriented frame.
+      */
             const Vector& velocity_error() const;
 
             const Vector& position() const;
@@ -74,6 +96,14 @@ namespace tsid {
             void Kd(ConstRefVector Kp);
 
             Index frame_id() const;
+
+            /**
+       * @brief Specifies if the jacobian and desired acceloration should be
+       * expressed in the local frame or the local world-oriented frame.
+       *
+       * @param local_frame If true, represent jacobian and acceloration in the
+       *   local frame. If false, represent them in the local world-oriented frame.
+       */
             void useLocalFrame(bool local_frame);
 
         protected:

--- a/example_project/src/tsid/ex_task.cpp
+++ b/example_project/src/tsid/ex_task.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 CNRS, NYU, MPI Tübingen
+// Copyright (c) 2017-2020 CNRS, NYU, MPI Tübingen, Inria
 //
 // This file is part of tsid
 // tsid is free software: you can redistribute it
@@ -15,12 +15,13 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-#include "tsid/tasks/ex_task.hpp"
 #include "tsid/math/utils.hpp"
 #include "tsid/robots/robot-wrapper.hpp"
+#include "tsid/tasks/ex_task.hpp"
 
 namespace tsid {
     namespace tasks {
+        using namespace std;
         using namespace math;
         using namespace trajectories;
         using namespace pinocchio;
@@ -93,9 +94,24 @@ namespace tsid {
         void ExTask::setReference(TrajectorySample& ref)
         {
             m_ref = ref;
-            vectorToSE3(ref.pos, m_M_ref);
-            m_v_ref = Motion(ref.vel);
-            m_a_ref = Motion(ref.acc);
+            TSID_DISABLE_WARNING_PUSH
+            TSID_DISABLE_WARNING_DEPRECATED
+            assert(ref.pos.size() == 12);
+            m_M_ref.translation(ref.pos.head<3>());
+            m_M_ref.rotation(MapMatrix3(&ref.pos(3), 3, 3));
+            TSID_DISABLE_WARNING_POP
+            m_v_ref = Motion(ref.getDerivative());
+            m_a_ref = Motion(ref.getSecondDerivative());
+        }
+
+        void ExTask::setReference(const SE3& ref)
+        {
+            TrajectorySample s(12, 6);
+            TSID_DISABLE_WARNING_PUSH
+            TSID_DISABLE_WARNING_DEPRECATED
+            tsid::math::SE3ToVector(ref, s.pos);
+            TSID_DISABLE_WARNING_POP
+            setReference(s);
         }
 
         const TrajectorySample& ExTask::getReference() const
@@ -174,7 +190,6 @@ namespace tsid {
             m_robot.frameJacobianLocal(data, m_frame_id, m_J);
 
             errorInSE3(oMi, m_M_ref, m_p_error); // pos err in local frame
-            m_p_error_vec = m_p_error.toVector();
             SE3ToVector(m_M_ref, m_p_ref);
             SE3ToVector(oMi, m_p);
 
@@ -182,23 +197,28 @@ namespace tsid {
             m_wMl.rotation(oMi.rotation());
 
             if (m_local_frame) {
-                m_v_error = v_frame - m_wMl.actInv(m_v_ref); // vel err in local frame
+                m_p_error_vec = m_p_error.toVector();
+                m_v_error = m_wMl.actInv(m_v_ref) - v_frame; // vel err in local frame
 
                 // desired acc in local frame
-                m_a_des = -m_Kp.cwiseProduct(m_p_error_vec)
-                    - m_Kd.cwiseProduct(m_v_error.toVector())
+                m_a_des = m_Kp.cwiseProduct(m_p_error_vec)
+                    + m_Kd.cwiseProduct(m_v_error.toVector())
                     + m_wMl.actInv(m_a_ref).toVector();
             }
             else {
                 m_p_error_vec = m_wMl.toActionMatrix() * // pos err in local world-oriented frame
                     m_p_error.toVector();
-                m_v_error = m_wMl.act(v_frame) - m_v_ref; // vel err in local world-oriented frame
+
+                // cout<<"m_p_error_vec="<<m_p_error_vec.head<3>().transpose()<<endl;
+                // cout<<"oMi-m_M_ref  ="<<-(oMi.translation()-m_M_ref.translation()).transpose()<<endl;
+
+                m_v_error = m_v_ref - m_wMl.act(v_frame); // vel err in local world-oriented frame
 
                 m_drift = m_wMl.act(m_drift);
 
                 // desired acc in local world-oriented frame
-                m_a_des = -m_Kp.cwiseProduct(m_p_error_vec)
-                    - m_Kd.cwiseProduct(m_v_error.toVector())
+                m_a_des = m_Kp.cwiseProduct(m_p_error_vec)
+                    + m_Kd.cwiseProduct(m_v_error.toVector())
                     + m_a_ref.toVector();
 
                 // Use an explicit temporary `m_J_rotated` here to avoid allocations.
@@ -224,6 +244,7 @@ namespace tsid {
 
                 idx += 1;
             }
+
             return m_constraint;
         }
     } // namespace tasks

--- a/include/inria_wbc/controllers/controller.hpp
+++ b/include/inria_wbc/controllers/controller.hpp
@@ -214,9 +214,9 @@ namespace inria_wbc {
         inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
         {
             tsid::trajectories::TrajectorySample sample;
-            sample.pos = ref;
-            sample.vel.setZero(ref.size());
-            sample.acc.setZero(ref.size());
+            sample.setValue(ref);
+            sample.setDerivative(Eigen::VectorXd::Zero(ref.size()));
+            sample.setSecondDerivative(Eigen::VectorXd::Zero(ref.size()));
             return sample;
         }
 
@@ -224,7 +224,11 @@ namespace inria_wbc {
         {
             tsid::trajectories::TrajectorySample sample;
             sample.resize(12, 6);
-            tsid::math::SE3ToVector(ref, sample.pos);
+
+            Eigen::VectorXd ref_vec(12);
+            tsid::math::SE3ToVector(ref, ref_vec);
+            sample.setValue(ref_vec);
+            
             return sample;
         }
 

--- a/include/inria_wbc/controllers/pos_tracker.hpp
+++ b/include/inria_wbc/controllers/pos_tracker.hpp
@@ -43,7 +43,7 @@ namespace inria_wbc {
             pinocchio::SE3 get_se3_ref(const std::string& task_name);
             tsid::trajectories::TrajectorySample get_full_se3_ref(const std::string& task_name) { return se3_task(task_name)->getReference(); }
             // we do not return the velocity for now
-            const tsid::math::Vector3 get_com_ref() { return com_task()->getReference().pos; }
+            const tsid::math::Vector3 get_com_ref() { return com_task()->getReference().getValue(); }
             const tsid::trajectories::TrajectorySample get_full_com_ref() { return com_task()->getReference(); }
             const tsid::trajectories::TrajectorySample get_full_momentum_ref() { return momentum_task()->getReference(); }
             void set_com_ref(const tsid::math::Vector3& ref) { com_task()->setReference(to_sample(ref)); }

--- a/include/inria_wbc/controllers/tasks.hpp
+++ b/include/inria_wbc/controllers/tasks.hpp
@@ -20,18 +20,19 @@ namespace inria_wbc {
 
     inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
     {
-        tsid::trajectories::TrajectorySample sample;
-        sample.pos = ref;
-        sample.vel.setZero(ref.size());
-        sample.acc.setZero(ref.size());
+        tsid::trajectories::TrajectorySample sample(ref.size());
+        sample.setValue(ref);
         return sample;
     }
 
     inline tsid::trajectories::TrajectorySample to_sample(const pinocchio::SE3& ref)
     {
-        tsid::trajectories::TrajectorySample sample;
-        sample.resize(12, 6);
-        tsid::math::SE3ToVector(ref, sample.pos);
+        tsid::trajectories::TrajectorySample sample(12, 6);
+
+        Eigen::VectorXd ref_vec(12);
+        tsid::math::SE3ToVector(ref, ref_vec);
+        sample.setValue(ref_vec);
+
         return sample;
     }
 

--- a/src/controllers/pos_tracker.cpp
+++ b/src/controllers/pos_tracker.cpp
@@ -151,7 +151,7 @@ namespace inria_wbc {
         {
             auto task = se3_task(task_name);
             pinocchio::SE3 se3;
-            auto pos = task->getReference().pos;
+            auto pos = task->getReference().getValue();
             tsid::math::vectorToSE3(pos, se3);
             return se3;
         }

--- a/src/controllers/talos_pos_tracker.cpp
+++ b/src/controllers/talos_pos_tracker.cpp
@@ -234,7 +234,7 @@ namespace inria_wbc {
             auto ac = activated_contacts_;
             for (auto& contact_name : ac) {
                 pinocchio::SE3 se3;
-                auto contact_pos = contact(contact_name)->getMotionTask().getReference().pos;
+                auto contact_pos = contact(contact_name)->getMotionTask().getReference().getValue();
                 tsid::math::vectorToSE3(contact_pos, se3);
                 contact_se3_ref[contact_name] = se3;
                 contact_sample_ref[contact_name] = contact(contact_name)->getMotionTask().getReference();
@@ -256,7 +256,7 @@ namespace inria_wbc {
                 IWBC_ASSERT(sensor_data.find("imu_vel") != sensor_data.end(), "the stabilizer imu needs angular velocity");
 
                 // estimate the CoP / ZMP
-                auto cops = _cop_estimator.update(com_ref.pos.head(2),
+                auto cops = _cop_estimator.update(com_ref.getValue().head(2),
                     model_joint_pos("leg_left_6_joint").translation(),
                     model_joint_pos("leg_right_6_joint").translation(),
                     sensor_data.at("lf_torque"), sensor_data.at("lf_force"),

--- a/src/tsid/task-momentum-equality.cpp
+++ b/src/tsid/task-momentum-equality.cpp
@@ -128,12 +128,12 @@ namespace tsid
     }
     const Vector & TaskMEquality::momentum_ref() const
     {
-      return m_ref.vel;
+      return m_ref.getDerivative();
     }
 
     const Vector & TaskMEquality::dmomentum_ref() const
     {
-      return m_ref.acc;
+      return m_ref.getSecondDerivative();
     }
 
     const ConstraintBase & TaskMEquality::getConstraint() const
@@ -150,8 +150,8 @@ namespace tsid
       // Get momentum jacobian
       const Matrix6x & J_am = m_robot.momentumJacobian(data);
       m_L = J_am * v;
-      m_L_error = m_L - m_ref.vel;
-      m_dL_des = - m_Kp.cwiseProduct(m_L_error) + m_ref.acc;
+      m_L_error = m_L - m_ref.getDerivative();
+      m_dL_des = - m_Kp.cwiseProduct(m_L_error) + m_ref.getSecondDerivative();
 
       m_drift.head(3) = pinocchio::computeCentroidalMomentumTimeVariation(m_robot.model(), const_cast<Data&>(data)).linear();
       m_drift.tail(3) = m_robot.angularMomentumTimeVariation(data);

--- a/tests/test_talos.cpp
+++ b/tests/test_talos.cpp
@@ -283,8 +283,8 @@ void test_behavior(utest::test_t test,
             floor_collision_map[s] = true;
 
         // compute the CoM error
-        error_com_dart += (robot->com() - p_controller->com_task()->getReference().pos).norm();
-        error_com_tsid += (p_controller->com() - p_controller->com_task()->getReference().pos).norm();
+        error_com_dart += (robot->com() - p_controller->com_task()->getReference().getValue()).norm();
+        error_com_tsid += (p_controller->com() - p_controller->com_task()->getReference().getValue()).norm();
 
         // tracking information
         for (auto& t : se3_tasks) {


### PR DESCRIPTION
tsid::TrajectorySample attributes are now deprecated and will be renamed.
To avoid warning and keep compatibility the following changes are made

change every write op on tsid::TrajectorySample as follow:
 - TrajectorySample.pos to TrajectorySample.setValue()
 - TrajectorySample.vel to TrajectorySample.setDerivative()
 - TrajectorySample.acc to TrajectorySample.setSecondDerivative()

change every read op on tsid::TrajectorySample as follow:
 - TrajectorySample.pos to TrajectorySample.getValue()
 - TrajectorySample.vel to TrajectorySample.getDerivative()
 - TrajectorySample.acc to TrajectorySample.getSecondDerivative()

