### PR TITLE
Task derivative refs

### DIFF
--- a/etc/talos/arm.yaml
+++ b/etc/talos/arm.yaml
@@ -1,6 +1,7 @@
 BEHAVIOR:
   name : generic::cartesian
   task_names: [lh]
-  relative_targets: [[0, 0, 0.1]]
-  trajectory_duration: 1
+  relative_targets_pos: [[0, 0, 0.5]]
+  relative_targets_rpy: [[]] # [[0, 0, -1.56]]
+  trajectory_duration: 2
   loop: true

--- a/etc/talos/arm.yaml
+++ b/etc/talos/arm.yaml
@@ -1,7 +1,8 @@
 BEHAVIOR:
   name : generic::cartesian
-  task_names: [lh]
-  relative_targets_pos: [[0, 0, 0.5]]
-  relative_targets_rpy: [[]] # [[0, 0, -1.56]]
-  trajectory_duration: 2
+  task_names: [lh, rh]
+  relative_targets_pos: [[0.3, -0.4, 0.0], [0.4, -5.7, -0.0]] # empty sublist for no target es. [[1,2,0], []]
+  relative_targets_rpy: [[0, 0, -1.56], [0, 0, +1.56]] # empty sublist for no target es. [[], [3.14,0,0]]
+  trajectory_duration: 1.5
   loop: true
+  

--- a/example_project/include/inria_wbc/behaviors/ex_behavior.hpp
+++ b/example_project/include/inria_wbc/behaviors/ex_behavior.hpp
@@ -6,7 +6,7 @@
 
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/example_project/src/behaviors/ex_behavior.cpp
+++ b/example_project/src/behaviors/ex_behavior.cpp
@@ -20,8 +20,8 @@ namespace inria_wbc {
             auto lh_final = lh_init;
             lh_final.translation()(2) += motion_size_;
 
-            trajectories_.push_back(trajectory_handler::compute_traj(lh_init, lh_final, controller_->dt(), trajectory_duration_));
-            trajectories_.push_back(trajectory_handler::compute_traj(lh_final, lh_init, controller_->dt(), trajectory_duration_));
+            trajectories_.push_back(trajs::min_jerk_trajectory(lh_init, lh_final, controller_->dt(), trajectory_duration_));
+            trajectories_.push_back(trajs::min_jerk_trajectory(lh_final, lh_init, controller_->dt(), trajectory_duration_));
             current_trajectory_ = trajectories_[traj_selector_];
         }
 

--- a/include/inria_wbc/behaviors/generic/cartesian.hpp
+++ b/include/inria_wbc/behaviors/generic/cartesian.hpp
@@ -6,7 +6,7 @@
 
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/include/inria_wbc/behaviors/generic/cartesian.hpp
+++ b/include/inria_wbc/behaviors/generic/cartesian.hpp
@@ -25,10 +25,12 @@ namespace inria_wbc {
                 int time_ = 0;
                 int traj_selector_ = 0;
                 std::vector<std::vector<std::vector<pinocchio::SE3>>> trajectories_;
-                float trajectory_duration_; //will be changed if specified in yaml
+                std::vector<std::vector<std::vector<Eigen::VectorXd>>> trajectories_d_;
+                std::vector<std::vector<std::vector<Eigen::VectorXd>>> trajectories_dd_;
+
+                float trajectory_duration_; // from YAML
                 std::vector<std::string> task_names_; // from YAML
-                std::vector<Eigen::Vector3d> relative_targets_; // form YAML
-                bool loop_;
+                bool loop_; // from YAML
             };
         } // namespace generic
     } // namespace behaviors

--- a/include/inria_wbc/behaviors/generic/cartesian_traj.hpp
+++ b/include/inria_wbc/behaviors/generic/cartesian_traj.hpp
@@ -6,7 +6,7 @@
 
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 #include <inria_wbc/trajs/loader.hpp>
 
 namespace inria_wbc {

--- a/include/inria_wbc/behaviors/humanoid/clapping.hpp
+++ b/include/inria_wbc/behaviors/humanoid/clapping.hpp
@@ -6,7 +6,7 @@
 
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/include/inria_wbc/behaviors/humanoid/squat.hpp
+++ b/include/inria_wbc/behaviors/humanoid/squat.hpp
@@ -6,7 +6,7 @@
 
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/pos_tracker.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/include/inria_wbc/behaviors/humanoid/squat.hpp
+++ b/include/inria_wbc/behaviors/humanoid/squat.hpp
@@ -24,8 +24,8 @@ namespace inria_wbc {
             private:
                 int time_ = 0;
                 int traj_selector_ = 0;
-                std::vector<std::vector<Eigen::VectorXd>> trajectories_;
-                std::vector<Eigen::VectorXd> current_trajectory_;
+                std::vector<std::vector<tsid::trajectories::TrajectorySample>> trajectories_;
+                std::vector<tsid::trajectories::TrajectorySample> current_trajectory_;
                 float trajectory_duration_ = 3; //will be changed if specified in yaml
                 float motion_size_ = 0.2; //will be changed if specified in yaml
             };

--- a/include/inria_wbc/behaviors/humanoid/walk.hpp
+++ b/include/inria_wbc/behaviors/humanoid/walk.hpp
@@ -7,7 +7,7 @@
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/talos_pos_tracker.hpp>
 #include <inria_wbc/estimators/cop.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
+++ b/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
@@ -25,16 +25,6 @@ namespace inria_wbc {
 
                 void _generate_trajectories();
 
-                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<pinocchio::SE3>& traj, 
-                    const std::vector<Eigen::VectorXd>& vels, const std::vector<Eigen::VectorXd>& accs) const;
-                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<Eigen::VectorXd>& traj, 
-                    const std::vector<Eigen::VectorXd>& vels, const std::vector<Eigen::VectorXd>& accs) const;
-                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<pinocchio::SE3>& traj) const;
-                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<Eigen::VectorXd>& traj) const;
-
-
-                pinocchio::SE3 se3_from_sample(const tsid::trajectories::TrajectorySample& sample) const;
-
                 int time_ = 0;
                 float dt_;
                 int _current_traj = 0;

--- a/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
+++ b/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
@@ -22,7 +22,19 @@ namespace inria_wbc {
                 std::string behavior_type() const override { return controllers::behavior_types::SINGLE_SUPPORT; };
 
             private:
+
                 void _generate_trajectories();
+
+                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<pinocchio::SE3>& traj, 
+                    const std::vector<Eigen::VectorXd>& vels, const std::vector<Eigen::VectorXd>& accs) const;
+                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<Eigen::VectorXd>& traj, 
+                    const std::vector<Eigen::VectorXd>& vels, const std::vector<Eigen::VectorXd>& accs) const;
+                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<pinocchio::SE3>& traj) const;
+                std::vector<tsid::trajectories::TrajectorySample> _to_sample_trajectory(const std::vector<Eigen::VectorXd>& traj) const;
+
+
+                pinocchio::SE3 se3_from_sample(const tsid::trajectories::TrajectorySample& sample) const;
+
                 int time_ = 0;
                 float dt_;
                 int _current_traj = 0;
@@ -30,12 +42,14 @@ namespace inria_wbc {
                 pinocchio::SE3 _last_lf;
                 pinocchio::SE3 _last_rf;
 
-                std::vector<std::vector<Eigen::VectorXd>> _com_trajs;
-                std::vector<std::vector<pinocchio::SE3>> _lf_trajs;
-                std::vector<std::vector<pinocchio::SE3>> _rf_trajs;
+                std::vector<std::vector<tsid::trajectories::TrajectorySample>> _com_trajs;
+                std::vector<std::vector<tsid::trajectories::TrajectorySample>> _lf_trajs;
+                std::vector<std::vector<tsid::trajectories::TrajectorySample>> _rf_trajs;
+
                 float traj_com_duration_ = 3; //will be changed if specified in yaml
                 float traj_foot_duration_ = 3; //will be changed if specified in yaml
                 float step_height_ = 0.1;
+
                 // State machine stats for walking on the spot cycle
                 int state_ = -1;
                 enum States {

--- a/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
+++ b/include/inria_wbc/behaviors/humanoid/walk_on_spot.hpp
@@ -7,7 +7,7 @@
 #include <inria_wbc/behaviors/behavior.hpp>
 #include <inria_wbc/controllers/talos_pos_tracker.hpp>
 #include <inria_wbc/estimators/cop.hpp>
-#include <inria_wbc/utils/trajectory_handler.hpp>
+#include <inria_wbc/trajs/trajectory_generator.hpp>
 
 namespace inria_wbc {
     namespace behaviors {

--- a/include/inria_wbc/controllers/controller.hpp
+++ b/include/inria_wbc/controllers/controller.hpp
@@ -211,23 +211,6 @@ namespace inria_wbc {
             std::shared_ptr<tsid::solvers::SolverHQPBase> solver_;
         };
 
-        inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
-        {
-            tsid::trajectories::TrajectorySample sample;
-            sample.pos = ref;
-            sample.vel.setZero(ref.size());
-            sample.acc.setZero(ref.size());
-            return sample;
-        }
-
-        inline tsid::trajectories::TrajectorySample to_sample(const pinocchio::SE3& ref)
-        {
-            tsid::trajectories::TrajectorySample sample;
-            sample.resize(12, 6);
-            tsid::math::SE3ToVector(ref, sample.pos);
-            return sample;
-        }
-
         using Factory = utils::Factory<Controller, YAML::Node>;
         template <typename T>
         using Register = Factory::AutoRegister<T>;

--- a/include/inria_wbc/controllers/pos_tracker.hpp
+++ b/include/inria_wbc/controllers/pos_tracker.hpp
@@ -3,6 +3,7 @@
 
 #include <inria_wbc/controllers/controller.hpp>
 #include <inria_wbc/estimators/cop.hpp>
+#include <inria_wbc/trajs/utils.hpp>
 
 namespace inria_wbc {
     namespace controllers {
@@ -46,7 +47,7 @@ namespace inria_wbc {
             const tsid::math::Vector3 get_com_ref() { return com_task()->getReference().pos; }
             const tsid::trajectories::TrajectorySample get_full_com_ref() { return com_task()->getReference(); }
             const tsid::trajectories::TrajectorySample get_full_momentum_ref() { return momentum_task()->getReference(); }
-            void set_com_ref(const tsid::math::Vector3& ref) { com_task()->setReference(to_sample(ref)); }
+            void set_com_ref(const tsid::math::Vector3& ref) { com_task()->setReference(trajs::to_sample(ref)); }
             void set_com_ref(const tsid::trajectories::TrajectorySample& sample) { com_task()->setReference(sample); }
             void set_momentum_ref(const tsid::trajectories::TrajectorySample& sample) { momentum_task()->setReference(sample); }
             void set_se3_ref(const pinocchio::SE3& ref, const std::string& task_name);

--- a/include/inria_wbc/controllers/tasks.hpp
+++ b/include/inria_wbc/controllers/tasks.hpp
@@ -18,23 +18,6 @@
 
 namespace inria_wbc {
 
-    inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
-    {
-        tsid::trajectories::TrajectorySample sample;
-        sample.pos = ref;
-        sample.vel.setZero(ref.size());
-        sample.acc.setZero(ref.size());
-        return sample;
-    }
-
-    inline tsid::trajectories::TrajectorySample to_sample(const pinocchio::SE3& ref)
-    {
-        tsid::trajectories::TrajectorySample sample;
-        sample.resize(12, 6);
-        tsid::math::SE3ToVector(ref, sample.pos);
-        return sample;
-    }
-
     namespace tasks {
         namespace cst {
             static constexpr double w_force_feet = 1e-3; // regularization force for contacts

--- a/include/inria_wbc/trajs/utils.hpp
+++ b/include/inria_wbc/trajs/utils.hpp
@@ -47,7 +47,7 @@ namespace inria_wbc {
             const Eigen::VectorXd& ref_vel, const Eigen::VectorXd& ref_acc)
         {
             IWBC_ASSERT(ref_vel.size() == 6, "velocity reference for SE3 must be a vector 6.");
-            IWBC_ASSERT(ref_vel.size() == 6, "acceleration reference for SE3 must be a vector 6.");
+            IWBC_ASSERT(ref_acc.size() == 6, "acceleration reference for SE3 must be a vector 6.");
 
             Eigen::VectorXd ref_vec(12);
 

--- a/include/inria_wbc/trajs/utils.hpp
+++ b/include/inria_wbc/trajs/utils.hpp
@@ -20,7 +20,7 @@ namespace inria_wbc {
         inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
         {
             tsid::trajectories::TrajectorySample sample(ref.size(), ref.size());
-            sample.pos = ref;
+            sample.setValue(ref);
             return sample;
         }
 

--- a/include/inria_wbc/trajs/utils.hpp
+++ b/include/inria_wbc/trajs/utils.hpp
@@ -1,0 +1,103 @@
+#ifndef IWBC_TRAJS_UTILS_HPP
+#define IWBC_TRAJS_UTILS_HPP
+
+#include <Eigen/Dense>
+#include <tsid/trajectories/trajectory-base.hpp>
+#include <tsid/math/utils.hpp>
+
+
+namespace inria_wbc {
+    namespace trajs {
+
+        inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
+        {
+            tsid::trajectories::TrajectorySample sample(ref.size(), ref.size());
+            sample.pos = ref;
+            return sample;
+        }
+
+        inline tsid::trajectories::TrajectorySample to_sample(const pinocchio::SE3& ref)
+        {
+            tsid::trajectories::TrajectorySample sample(12,6);
+            Eigen::VectorXd ref_vec(12);
+            tsid::math::SE3ToVector(ref, ref_vec);
+            sample.setValue(ref_vec);
+            return sample;
+        }
+
+        inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref, 
+            const Eigen::VectorXd& ref_vel, const Eigen::VectorXd& ref_acc)
+        {
+            tsid::trajectories::TrajectorySample sample(ref.size(), ref.size());
+            sample.setValue(ref);
+            sample.setDerivative(ref_vel);
+            sample.setSecondDerivative(ref_acc);
+            return sample;
+        }
+
+        inline tsid::trajectories::TrajectorySample to_sample(const pinocchio::SE3& ref, 
+            const Eigen::VectorXd& ref_vel, const Eigen::VectorXd& ref_acc)
+        {
+            IWBC_ASSERT(ref_vel.size() == 6, "velocity reference for SE3 must be a vector 6.");
+            IWBC_ASSERT(ref_vel.size() == 6, "acceleration reference for SE3 must be a vector 6.");
+
+            Eigen::VectorXd ref_vec(12);
+
+            tsid::trajectories::TrajectorySample sample(12,6);
+            tsid::math::SE3ToVector(ref, ref_vec);
+            sample.setValue(ref_vec);
+            sample.setDerivative(ref_vel);
+            sample.setSecondDerivative(ref_acc);
+            return sample;
+        }
+
+        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+            const std::vector<pinocchio::SE3>& traj)
+        {
+            std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
+            for(int i=0; i < traj.size(); ++i)
+                sample_trajectory.push_back(to_sample(traj[i]));
+            return sample_trajectory;
+        }
+
+        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+            const std::vector<pinocchio::SE3>& traj, const std::vector<Eigen::VectorXd>& vels, 
+            const std::vector<Eigen::VectorXd>& accs)
+        {
+            std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
+            for(int i=0; i < traj.size(); ++i)
+                sample_trajectory.push_back(to_sample(traj[i], vels[i], accs[i]));
+            return sample_trajectory;
+        }
+
+        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+            const std::vector<Eigen::VectorXd>& traj)
+        {
+            std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
+            for(int i=0; i < traj.size(); ++i)
+                sample_trajectory.push_back(to_sample(traj[i]));
+            return sample_trajectory;
+        }
+
+        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+            const std::vector<Eigen::VectorXd>& traj, const std::vector<Eigen::VectorXd>& vels, 
+            const std::vector<Eigen::VectorXd>& accs)
+        {
+            std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
+            for(int i=0; i < traj.size(); ++i)
+                sample_trajectory.push_back(to_sample(traj[i], vels[i], accs[i]));
+            return sample_trajectory;
+        }
+
+        pinocchio::SE3 se3_from_sample(const tsid::trajectories::TrajectorySample& sample)
+        {
+            pinocchio::SE3 se3;
+            se3.translation() = sample.getValue().head<3>();
+            se3.rotation() = Eigen::Matrix3d::Map(sample.getValue().data()+3);
+            return se3;
+        }
+
+    } // namespace trajs
+} // namespace inria_wbc
+
+#endif // IWBC_TRAJS_UTILS_HPP

--- a/include/inria_wbc/trajs/utils.hpp
+++ b/include/inria_wbc/trajs/utils.hpp
@@ -9,6 +9,14 @@
 namespace inria_wbc {
     namespace trajs {
 
+        inline pinocchio::SE3 se3_from_sample(const tsid::trajectories::TrajectorySample& sample)
+        {
+            pinocchio::SE3 se3;
+            se3.translation() = sample.getValue().head<3>();
+            se3.rotation() = Eigen::Matrix3d::Map(sample.getValue().data()+3);
+            return se3;
+        }
+
         inline tsid::trajectories::TrajectorySample to_sample(const Eigen::VectorXd& ref)
         {
             tsid::trajectories::TrajectorySample sample(ref.size(), ref.size());
@@ -51,7 +59,7 @@ namespace inria_wbc {
             return sample;
         }
 
-        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+        inline std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
             const std::vector<pinocchio::SE3>& traj)
         {
             std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
@@ -60,7 +68,7 @@ namespace inria_wbc {
             return sample_trajectory;
         }
 
-        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+        inline std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
             const std::vector<pinocchio::SE3>& traj, const std::vector<Eigen::VectorXd>& vels, 
             const std::vector<Eigen::VectorXd>& accs)
         {
@@ -70,7 +78,7 @@ namespace inria_wbc {
             return sample_trajectory;
         }
 
-        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+        inline std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
             const std::vector<Eigen::VectorXd>& traj)
         {
             std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
@@ -79,7 +87,7 @@ namespace inria_wbc {
             return sample_trajectory;
         }
 
-        std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
+        inline std::vector<tsid::trajectories::TrajectorySample> to_sample_trajectory(
             const std::vector<Eigen::VectorXd>& traj, const std::vector<Eigen::VectorXd>& vels, 
             const std::vector<Eigen::VectorXd>& accs)
         {
@@ -87,14 +95,6 @@ namespace inria_wbc {
             for(int i=0; i < traj.size(); ++i)
                 sample_trajectory.push_back(to_sample(traj[i], vels[i], accs[i]));
             return sample_trajectory;
-        }
-
-        pinocchio::SE3 se3_from_sample(const tsid::trajectories::TrajectorySample& sample)
-        {
-            pinocchio::SE3 se3;
-            se3.translation() = sample.getValue().head<3>();
-            se3.rotation() = Eigen::Matrix3d::Map(sample.getValue().data()+3);
-            return se3;
         }
 
     } // namespace trajs

--- a/include/inria_wbc/utils/trajectory_handler.hpp
+++ b/include/inria_wbc/utils/trajectory_handler.hpp
@@ -12,20 +12,67 @@
 
 namespace trajectory_handler {
 
-    inline Eigen::VectorXd minimum_jerk_polynom(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
+    namespace order
+    {
+        constexpr uint16_t ZERO = 0;
+        constexpr uint16_t FIRST = 1;
+        constexpr uint16_t SECOND = 2;
+    }
+
+    template <uint16_t d_order>
+    Eigen::VectorXd minimum_jerk_polynom(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
+    {
+       IWBC_ERROR("minimum_jerk_polynom is not implemented for " + std::to_string(d_order) + " derivative order.");
+    }
+
+    template <>
+    inline Eigen::VectorXd minimum_jerk_polynom<order::ZERO>(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
     {
         assertm(x0.size() == xf.size(), "minimum_jerk_polynom x0 and xf should have the same size");
         double td = t / trajectory_duration;
-        Eigen::VectorXd xt = x0 + (xf - x0) * (6 * td * td * td * td * td - 15 * td * td * td * td + 10 * td * td * td);
+        double td_pow_3 = std::pow(td, 3);
+
+        Eigen::VectorXd xt = x0 + (xf - x0) * (6 * td * td * td_pow_3 - 15 * td * td_pow_3 + 10 * td_pow_3);
         return xt;
     }
 
+    // first order derivative value of minimum jerk polynom at time t
+    template <>
+    inline Eigen::VectorXd minimum_jerk_polynom<order::FIRST>(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
+    {
+        assertm(x0.size() == xf.size(), "minimum_jerk_polynom x0 and xf should have the same size");
+        double td = t / trajectory_duration;
+        double td_pow_2 = td * td;
+        Eigen::VectorXd xt = (xf - x0) * (30 * td * td * td_pow_2 - 60 * td * td_pow_2  + 30 * td_pow_2);
+        return xt;
+    }
+
+    // second order derivative value of minimum jerk polynom at time t
+    template <>
+    inline Eigen::VectorXd minimum_jerk_polynom<order::SECOND>(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
+    {
+        assertm(x0.size() == xf.size(), "minimum_jerk_polynom x0 and xf should have the same size");
+        double td = t / trajectory_duration;
+        Eigen::VectorXd xt = (xf - x0) * (120 * td * td * td - 120 * td * td  + 60 * td);
+        return xt;
+    }
+
+    inline Eigen::VectorXd minimum_jerk_polynom(const Eigen::VectorXd& x0, const Eigen::VectorXd& xf, double t, double trajectory_duration)
+    {
+        return minimum_jerk_polynom<order::ZERO>(x0, xf, t, trajectory_duration);
+    }
+
+
+    template <uint8_t DO = order::ZERO>
     inline std::vector<Eigen::VectorXd> compute_traj(const Eigen::VectorXd& start, const Eigen::VectorXd& dest, double dt, double trajectory_duration)
     {
+        if(DO > order::SECOND)
+            IWBC_ERROR("compute_traj is not implemented for " + std::to_string(DO) + " derivative order.");
+        
         uint n_steps = std::floor(trajectory_duration / dt);
         std::vector<Eigen::VectorXd> trajectory(n_steps);
         for (uint i = 0; i < n_steps; i++)
-            trajectory[i] = minimum_jerk_polynom(start, dest, dt * i, trajectory_duration);
+            trajectory[i] = minimum_jerk_polynom<DO>(start, dest, dt * i, trajectory_duration);
         return trajectory;
     }
 

--- a/include/inria_wbc/utils/trajectory_handler.hpp
+++ b/include/inria_wbc/utils/trajectory_handler.hpp
@@ -63,16 +63,82 @@ namespace trajectory_handler {
     }
 
 
-    template <uint8_t DO = order::ZERO>
+    template <uint16_t ORDER = order::ZERO>
     inline std::vector<Eigen::VectorXd> compute_traj(const Eigen::VectorXd& start, const Eigen::VectorXd& dest, double dt, double trajectory_duration)
     {
-        if(DO > order::SECOND)
-            IWBC_ERROR("compute_traj is not implemented for " + std::to_string(DO) + " derivative order.");
+        if(ORDER > order::SECOND)
+            IWBC_ERROR("compute_traj is not implemented for derivative of order " + std::to_string(ORDER) + ".");
         
         uint n_steps = std::floor(trajectory_duration / dt);
         std::vector<Eigen::VectorXd> trajectory(n_steps);
         for (uint i = 0; i < n_steps; i++)
-            trajectory[i] = minimum_jerk_polynom<DO>(start, dest, dt * i, trajectory_duration);
+            trajectory[i] = minimum_jerk_polynom<ORDER>(start, dest, dt * i, trajectory_duration);
+        return trajectory;
+    }
+
+    // inline std::vector<pinocchio::SE3> compute_traj(const pinocchio::SE3& start, const pinocchio::SE3& dest, double dt, double trajectory_duration)
+    // {
+    //     Eigen::Vector3d pos_start, pos_dest, pos_xt;
+    //     pos_start = start.translation();
+    //     pos_dest = dest.translation();
+    //     Eigen::Quaterniond quat_start(start.rotation());
+    //     Eigen::Quaterniond quat_dest(dest.rotation());
+
+    //     // Interpolate time as min jerk to use in slerp routine (otherwise slerp gives constant angular velocity result)
+    //     Eigen::VectorXd t_start(1), t_dest(1), t_xt(1);
+    //     t_start << 0.;
+    //     t_dest << 1.;
+
+    //     uint n_steps = std::floor(trajectory_duration / dt);
+    //     std::vector<pinocchio::SE3> trajectory;
+
+    //     for (uint i = 0; i < n_steps; i++) {
+    //         // Min jerk trajectory for translation
+    //         pos_xt = minimum_jerk_polynom(pos_start, pos_dest, dt * i, trajectory_duration);
+    //         t_xt = minimum_jerk_polynom(t_start, t_dest, dt * i, trajectory_duration);
+    //         // Slerp interpolation for quaternion
+    //         Eigen::Quaterniond quat_xt = quat_start.slerp(t_xt(0), quat_dest);
+    //         pinocchio::SE3 xt = pinocchio::SE3(quat_xt, pos_xt);
+    //         trajectory.push_back(xt);
+    //     }
+    //     return trajectory;
+    // }
+
+
+    template<uint16_t ORDER>
+    inline std::vector<Eigen::VectorXd> compute_traj(const pinocchio::SE3& start, const pinocchio::SE3& dest, double dt, double trajectory_duration)
+    {
+        if(ORDER > order::SECOND || ORDER < order::FIRST)
+            IWBC_ERROR("compute_traj is not implemented for derivative of order " + std::to_string(ORDER) + ".");
+
+        Eigen::Vector3d pos_start, pos_dest, pos_d_xt;
+        pos_start = start.translation();
+        pos_dest = dest.translation();
+
+        Eigen::AngleAxisd aa_rot(start.rotation().transpose() * dest.rotation());
+        const Eigen::Vector3d& rot_axis = aa_rot.axis();
+        double rot_angle = aa_rot.angle();
+
+        // Interpolate time as min jerk to use in slerp routine (otherwise slerp gives constant angular velocity result)
+        Eigen::VectorXd ang_start(1), ang_dest(1), ang_d_xt(1);
+        ang_start << 0.;
+        ang_dest << rot_angle;
+
+        uint n_steps = std::floor(trajectory_duration / dt);
+        std::vector<Eigen::VectorXd> trajectory;
+
+        for (uint i = 0; i < n_steps; i++) {
+            Eigen::Matrix<double,6,1> d_vec;
+
+            // Min jerk trajectory for translation
+            pos_d_xt = minimum_jerk_polynom<ORDER>(pos_start, pos_dest, dt * i, trajectory_duration);
+            ang_d_xt = minimum_jerk_polynom<ORDER>(ang_start, ang_dest, dt * i, trajectory_duration);
+
+            d_vec.head<3>() = pos_d_xt;
+            d_vec.tail<3>() = (ang_d_xt(0) * rot_axis);
+
+            trajectory.push_back(d_vec);
+        }
         return trajectory;
     }
 
@@ -81,24 +147,28 @@ namespace trajectory_handler {
         Eigen::Vector3d pos_start, pos_dest, pos_xt;
         pos_start = start.translation();
         pos_dest = dest.translation();
-        Eigen::Quaterniond quat_start(start.rotation());
-        Eigen::Quaterniond quat_dest(dest.rotation());
+
+        Eigen::AngleAxisd aa_rot(start.rotation().transpose() * dest.rotation());
+        const Eigen::Vector3d& rot_axis = aa_rot.axis();
+        double rot_angle = aa_rot.angle();
 
         // Interpolate time as min jerk to use in slerp routine (otherwise slerp gives constant angular velocity result)
-        Eigen::VectorXd t_start(1), t_dest(1), t_xt(1);
-        t_start << 0.;
-        t_dest << 1.;
+        Eigen::VectorXd ang_start(1), ang_dest(1), ang_xt(1);
+        ang_start << 0.;
+        ang_dest << rot_angle;
 
         uint n_steps = std::floor(trajectory_duration / dt);
         std::vector<pinocchio::SE3> trajectory;
 
         for (uint i = 0; i < n_steps; i++) {
-            // Min jerk trajectory for translation
+
+            // Min jerk trajectory for translation and rotation
             pos_xt = minimum_jerk_polynom(pos_start, pos_dest, dt * i, trajectory_duration);
-            t_xt = minimum_jerk_polynom(t_start, t_dest, dt * i, trajectory_duration);
-            // Slerp interpolation for quaternion
-            Eigen::Quaterniond quat_xt = quat_start.slerp(t_xt(0), quat_dest);
-            pinocchio::SE3 xt = pinocchio::SE3(quat_xt, pos_xt);
+            ang_xt = minimum_jerk_polynom(ang_start, ang_dest, dt * i, trajectory_duration);
+
+            Eigen::Matrix3d rot_xt = start.rotation() * Eigen::AngleAxisd(ang_xt(0), rot_axis).toRotationMatrix();
+
+            pinocchio::SE3 xt = pinocchio::SE3(rot_xt, pos_xt);
             trajectory.push_back(xt);
         }
         return trajectory;
@@ -112,5 +182,6 @@ namespace trajectory_handler {
         std::fill(trajectory.begin(), trajectory.end(), p);
         return trajectory;
     }
+
 } // namespace trajectory_handler
 #endif

--- a/include/inria_wbc/utils/trajectory_handler.hpp
+++ b/include/inria_wbc/utils/trajectory_handler.hpp
@@ -135,7 +135,7 @@ namespace trajectory_handler {
             ang_d_xt = minimum_jerk_polynom<ORDER>(ang_start, ang_dest, dt * i, trajectory_duration);
 
             d_vec.head<3>() = pos_d_xt;
-            d_vec.tail<3>() = (ang_d_xt(0) * rot_axis);
+            d_vec.tail<3>() = start.rotation() * (ang_d_xt(0) * rot_axis);
 
             trajectory.push_back(d_vec);
         }

--- a/include/inria_wbc/utils/trajectory_handler.hpp
+++ b/include/inria_wbc/utils/trajectory_handler.hpp
@@ -43,7 +43,7 @@ namespace trajectory_handler {
         assertm(x0.size() == xf.size(), "minimum_jerk_polynom x0 and xf should have the same size");
         double td = t / trajectory_duration;
         double td_pow_2 = td * td;
-        Eigen::VectorXd xt = (xf - x0) * (30 * td * td * td_pow_2 - 60 * td * td_pow_2  + 30 * td_pow_2);
+        Eigen::VectorXd xt = (xf - x0) * (30 * td * td * td_pow_2 - 60 * td * td_pow_2  + 30 * td_pow_2) / trajectory_duration;
         return xt;
     }
 
@@ -53,7 +53,7 @@ namespace trajectory_handler {
     {
         assertm(x0.size() == xf.size(), "minimum_jerk_polynom x0 and xf should have the same size");
         double td = t / trajectory_duration;
-        Eigen::VectorXd xt = (xf - x0) * (120 * td * td * td - 120 * td * td  + 60 * td);
+        Eigen::VectorXd xt = (xf - x0) * (120 * td * td * td - 180 * td * td  + 60 * td) / std::pow(trajectory_duration, 2.0);
         return xt;
     }
 

--- a/src/behaviors/generic/cartesian.cpp
+++ b/src/behaviors/generic/cartesian.cpp
@@ -8,6 +8,9 @@ namespace inria_wbc {
             Cartesian::Cartesian(const controller_ptr_t& controller, const YAML::Node& config) : Behavior(controller, config),
                                                                                                  traj_selector_(0)
             {
+
+                namespace trh = trajectory_handler;
+
                 auto c = IWBC_CHECK(config["BEHAVIOR"]);
                 trajectory_duration_ = IWBC_CHECK(c["trajectory_duration"].as<float>());
                 behavior_type_ = this->behavior_type();
@@ -15,37 +18,72 @@ namespace inria_wbc {
 
                 loop_ = IWBC_CHECK(c["loop"].as<bool>());
                 task_names_ = IWBC_CHECK(c["task_names"].as<std::vector<std::string>>());
-                auto ts = IWBC_CHECK(c["relative_targets"].as<std::vector<std::vector<double>>>());
+                auto ts = IWBC_CHECK(c["relative_targets_pos"].as<std::vector<std::vector<double>>>());
+                auto to = IWBC_CHECK(c["relative_targets_rpy"].as<std::vector<std::vector<double>>>());
 
                 if (task_names_.size() != ts.size())
                     IWBC_ERROR("cartesian behavior needs the same number of tasks and targets");
 
                 for (uint i = 0; i < task_names_.size(); i++) {
+
                     auto task_init = std::static_pointer_cast<inria_wbc::controllers::PosTracker>(controller_)->get_se3_ref(task_names_[i]);
                     auto task_final = task_init;
 
-                    relative_targets_.push_back(Eigen::Vector3d::Map(ts[i].data()));
-                    task_final.translation() = relative_targets_[i] + task_init.translation();
+                    if(ts[i].size() == 3)
+                        task_final.translation() = Eigen::Vector3d::Map(ts[i].data()) + task_init.translation();
+
+                    if(to[i].size() == 3)
+                    {
+                        Eigen::Matrix3d rot = (Eigen::AngleAxisd(to[i][2], Eigen::Vector3d::UnitZ())
+                            * Eigen::AngleAxisd(to[i][1], Eigen::Vector3d::UnitY())
+                            * Eigen::AngleAxisd(to[i][0], Eigen::Vector3d::UnitX())).toRotationMatrix();
+
+                        task_final.rotation() = rot * task_init.rotation();
+                    }
 
                     std::vector<std::vector<pinocchio::SE3>> trajectory;
-                    trajectory.push_back(trajectory_handler::compute_traj(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    std::vector<std::vector<Eigen::VectorXd>> trajectory_d;
+                    std::vector<std::vector<Eigen::VectorXd>> trajectory_dd;
+
+                    trajectory.push_back(trh::compute_traj(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    trajectory_d.push_back(trh::compute_traj<trh::order::FIRST>(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    trajectory_dd.push_back(trh::compute_traj<trh::order::SECOND>(task_init, task_final, controller_->dt(), trajectory_duration_));
+
                     if (loop_)
-                        trajectory.push_back(trajectory_handler::compute_traj(task_final, task_init, controller_->dt(), trajectory_duration_));
+                    {
+                        trajectory.push_back(trh::compute_traj(task_final, task_init, controller_->dt(), trajectory_duration_));
+                        trajectory_d.push_back(trh::compute_traj<trh::order::FIRST>(task_final, task_init, controller_->dt(), trajectory_duration_));
+                        trajectory_dd.push_back(trh::compute_traj<trh::order::SECOND>(task_final, task_init, controller_->dt(), trajectory_duration_));
+                    }
+
                     trajectories_.push_back(trajectory);
+                    trajectories_d_.push_back(trajectory_d);
+                    trajectories_dd_.push_back(trajectory_dd);
                 }
+
+
             }
 
             void Cartesian::update(const controllers::SensorData& sensor_data)
             {
                 for (uint i = 0; i < task_names_.size(); i++) {
                     if (traj_selector_ < trajectories_[i].size()) {
+
                         auto ref = trajectories_[i][traj_selector_][time_];
-                        std::static_pointer_cast<inria_wbc::controllers::PosTracker>(controller_)->set_se3_ref(ref, task_names_[i]);
+                        Eigen::VectorXd ref_vec(12);
+                        tsid::math::SE3ToVector(ref, ref_vec);
+
+                        tsid::trajectories::TrajectorySample sample_ref(12,6);
+                        sample_ref.setValue(ref_vec);
+                        // sample_ref.setDerivative( trajectories_d_[i][traj_selector_][time_] );
+                        // sample_ref.setSecondDerivative( trajectories_dd_[i][traj_selector_][time_] );
+
+                        std::static_pointer_cast<inria_wbc::controllers::PosTracker>(controller_)->set_se3_ref(sample_ref, task_names_[i]);
                     }
                 }
 
                 controller_->update(sensor_data);
-                time_++;
+                ++time_;
                 if (trajectories_.size() > 0) {
                     if (time_ == trajectories_[0][traj_selector_].size()) {
                         time_ = 0;

--- a/src/behaviors/generic/cartesian.cpp
+++ b/src/behaviors/generic/cartesian.cpp
@@ -9,8 +9,6 @@ namespace inria_wbc {
                                                                                                  traj_selector_(0)
             {
 
-                namespace trh = trajectory_handler;
-
                 auto c = IWBC_CHECK(config["BEHAVIOR"]);
                 trajectory_duration_ = IWBC_CHECK(c["trajectory_duration"].as<float>());
                 behavior_type_ = this->behavior_type();
@@ -45,15 +43,15 @@ namespace inria_wbc {
                     std::vector<std::vector<Eigen::VectorXd>> trajectory_d;
                     std::vector<std::vector<Eigen::VectorXd>> trajectory_dd;
 
-                    trajectory.push_back(trh::compute_traj(task_init, task_final, controller_->dt(), trajectory_duration_));
-                    trajectory_d.push_back(trh::compute_traj<trh::order::FIRST>(task_init, task_final, controller_->dt(), trajectory_duration_));
-                    trajectory_dd.push_back(trh::compute_traj<trh::order::SECOND>(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    trajectory.push_back(trajs::min_jerk_trajectory(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    trajectory_d.push_back(trajs::min_jerk_trajectory<trajs::d_order::FIRST>(task_init, task_final, controller_->dt(), trajectory_duration_));
+                    trajectory_dd.push_back(trajs::min_jerk_trajectory<trajs::d_order::SECOND>(task_init, task_final, controller_->dt(), trajectory_duration_));
 
                     if (loop_)
                     {
-                        trajectory.push_back(trh::compute_traj(task_final, task_init, controller_->dt(), trajectory_duration_));
-                        trajectory_d.push_back(trh::compute_traj<trh::order::FIRST>(task_final, task_init, controller_->dt(), trajectory_duration_));
-                        trajectory_dd.push_back(trh::compute_traj<trh::order::SECOND>(task_final, task_init, controller_->dt(), trajectory_duration_));
+                        trajectory.push_back(trajs::min_jerk_trajectory(task_final, task_init, controller_->dt(), trajectory_duration_));
+                        trajectory_d.push_back(trajs::min_jerk_trajectory<trajs::d_order::FIRST>(task_final, task_init, controller_->dt(), trajectory_duration_));
+                        trajectory_dd.push_back(trajs::min_jerk_trajectory<trajs::d_order::SECOND>(task_final, task_init, controller_->dt(), trajectory_duration_));
                     }
 
                     trajectories_.push_back(trajectory);

--- a/src/behaviors/generic/cartesian.cpp
+++ b/src/behaviors/generic/cartesian.cpp
@@ -75,8 +75,8 @@ namespace inria_wbc {
 
                         tsid::trajectories::TrajectorySample sample_ref(12,6);
                         sample_ref.setValue(ref_vec);
-                        // sample_ref.setDerivative( trajectories_d_[i][traj_selector_][time_] );
-                        // sample_ref.setSecondDerivative( trajectories_dd_[i][traj_selector_][time_] );
+                        sample_ref.setDerivative( trajectories_d_[i][traj_selector_][time_] );
+                        sample_ref.setSecondDerivative( trajectories_dd_[i][traj_selector_][time_] );
 
                         std::static_pointer_cast<inria_wbc::controllers::PosTracker>(controller_)->set_se3_ref(sample_ref, task_names_[i]);
                     }

--- a/src/behaviors/humanoid/clapping.cpp
+++ b/src/behaviors/humanoid/clapping.cpp
@@ -26,10 +26,10 @@ namespace inria_wbc {
                 lh_final.translation()(1) -= motion_size_;
                 rh_final.translation()(1) += motion_size_;
 
-                lh_trajs_.push_back(trajectory_handler::compute_traj(lh_init, lh_final, controller_->dt(), trajectory_duration_));
-                lh_trajs_.push_back(trajectory_handler::compute_traj(lh_final, lh_init, controller_->dt(), trajectory_duration_));
-                rh_trajs_.push_back(trajectory_handler::compute_traj(rh_init, rh_final, controller_->dt(), trajectory_duration_));
-                rh_trajs_.push_back(trajectory_handler::compute_traj(rh_final, rh_init, controller_->dt(), trajectory_duration_));
+                lh_trajs_.push_back(trajs::min_jerk_trajectory(lh_init, lh_final, controller_->dt(), trajectory_duration_));
+                lh_trajs_.push_back(trajs::min_jerk_trajectory(lh_final, lh_init, controller_->dt(), trajectory_duration_));
+                rh_trajs_.push_back(trajs::min_jerk_trajectory(rh_init, rh_final, controller_->dt(), trajectory_duration_));
+                rh_trajs_.push_back(trajs::min_jerk_trajectory(rh_final, rh_init, controller_->dt(), trajectory_duration_));
             }
 
             void Clapping::update(const controllers::SensorData& sensor_data)

--- a/src/behaviors/humanoid/squat.cpp
+++ b/src/behaviors/humanoid/squat.cpp
@@ -21,8 +21,20 @@ namespace inria_wbc {
                 auto com_final = com_init;
                 com_final(2) -= motion_size_;
 
-                trajectories_.push_back(trajs::min_jerk_trajectory(com_init, com_final, controller_->dt(), trajectory_duration_));
-                trajectories_.push_back(trajs::min_jerk_trajectory(com_final, com_init, controller_->dt(), trajectory_duration_));
+                trajectories_.push_back(
+                    trajs::to_sample_trajectory(
+                        trajs::min_jerk_trajectory(com_init, com_final, controller_->dt(), trajectory_duration_),
+                        trajs::min_jerk_trajectory<trajs::d_order::FIRST>(com_init, com_final, controller_->dt(), trajectory_duration_),
+                        trajs::min_jerk_trajectory<trajs::d_order::SECOND>(com_init, com_final, controller_->dt(), trajectory_duration_)
+                    )
+                );
+                trajectories_.push_back(
+                    trajs::to_sample_trajectory(
+                        trajs::min_jerk_trajectory(com_final, com_init, controller_->dt(), trajectory_duration_),
+                        trajs::min_jerk_trajectory<trajs::d_order::FIRST>(com_final, com_init, controller_->dt(), trajectory_duration_),
+                        trajs::min_jerk_trajectory<trajs::d_order::SECOND>(com_final, com_init, controller_->dt(), trajectory_duration_)
+                    )
+                );
                 current_trajectory_ = trajectories_[traj_selector_];
             }
 

--- a/src/behaviors/humanoid/squat.cpp
+++ b/src/behaviors/humanoid/squat.cpp
@@ -21,8 +21,8 @@ namespace inria_wbc {
                 auto com_final = com_init;
                 com_final(2) -= motion_size_;
 
-                trajectories_.push_back(trajectory_handler::compute_traj(com_init, com_final, controller_->dt(), trajectory_duration_));
-                trajectories_.push_back(trajectory_handler::compute_traj(com_final, com_init, controller_->dt(), trajectory_duration_));
+                trajectories_.push_back(trajs::min_jerk_trajectory(com_init, com_final, controller_->dt(), trajectory_duration_));
+                trajectories_.push_back(trajs::min_jerk_trajectory(com_final, com_init, controller_->dt(), trajectory_duration_));
                 current_trajectory_ = trajectories_[traj_selector_];
             }
 

--- a/src/behaviors/humanoid/walk.cpp
+++ b/src/behaviors/humanoid/walk.cpp
@@ -91,88 +91,88 @@ namespace inria_wbc {
                 for (auto c : cycle_) {
                     switch (c) {
                     case States::INIT:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_init, com_rf, dt_, traj_com_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_init, com_rf, dt_, traj_com_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::LF_INIT:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_low, lf_high, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_foot_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_foot_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_low, lf_high, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_foot_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_foot_duration_));
                         break;
                     case States::LIFT_DOWN_LF:
                         diff = rf_low.translation()(0) - lf_low.translation()(0);
                         lf_low = translate(lf_low, diff + step_length_, 0);
                         lh_forward = translate(lh_init, diff + step_length_, 0);
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_high, lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::compute_traj(lh_init, lh_forward, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_high, lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::min_jerk_trajectory(lh_init, lh_forward, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         lh_init = lh_forward;
                         break;
                     case States::MOVE_COM_LEFT:
                         com_lf(0) = lf_low.translation()(0);
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_rf, com_lf, dt_, traj_com_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_rf, com_lf, dt_, traj_com_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_UP_RF:
                         rf_high.translation()(0) = lf_low.translation()(0);
-                        _rf_trajs.push_back(trajectory_handler::compute_traj(rf_low, rf_high, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_lf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::min_jerk_trajectory(rf_low, rf_high, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_lf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_DOWN_RF:
                         rf_low = translate(rf_low, 2 * step_length_, 0);
                         rh_forward = translate(rh_init, 2 * step_length_, 0);
-                        _rf_trajs.push_back(trajectory_handler::compute_traj(rf_high, rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_lf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::compute_traj(rh_init, rh_forward, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::min_jerk_trajectory(rf_high, rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_lf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::min_jerk_trajectory(rh_init, rh_forward, dt_, traj_com_duration_));
                         rh_init = rh_forward;
                         break;
                     case States::MOVE_COM_RIGHT:
                         com_rf(0) = rf_low.translation()(0);
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_lf, com_rf, dt_, traj_com_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_lf, com_rf, dt_, traj_com_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_UP_LF:
                         lf_high.translation()(0) = rf_low.translation()(0);
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_low, lf_high, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_init, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_low, lf_high, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_init, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_DOWN_LF_FINAL:
                         lf_low = translate(lf_low, step_length_, 0);
                         lh_forward = translate(lh_init, step_length_, 0);
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_high, lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
-                        _lh_trajs.push_back(trajectory_handler::compute_traj(lh_init, lh_forward, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_init, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_high, lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _lh_trajs.push_back(trajs::min_jerk_trajectory(lh_init, lh_forward, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_init, dt_, traj_com_duration_));
                         break;
                     case States::MOVE_COM_CENTER_FINAL:
                         com_init.head(2) = (rf_low.translation().head(2) + lf_low.translation().head(2)) / 2.0;
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_rf, com_init, dt_, traj_com_duration_));
-                        _lh_trajs.push_back(trajectory_handler::constant_traj(lh_forward, dt_, traj_com_duration_));
-                        _rh_trajs.push_back(trajectory_handler::constant_traj(rh_forward, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_rf, com_init, dt_, traj_com_duration_));
+                        _lh_trajs.push_back(trajs::constant_traj(lh_forward, dt_, traj_com_duration_));
+                        _rh_trajs.push_back(trajs::constant_traj(rh_forward, dt_, traj_com_duration_));
                         break;
                     default:
                         assert(0 && "unknown state");

--- a/src/behaviors/humanoid/walk_on_spot.cpp
+++ b/src/behaviors/humanoid/walk_on_spot.cpp
@@ -1,4 +1,5 @@
 #include "inria_wbc/behaviors/humanoid/walk_on_spot.hpp"
+#include <inria_wbc/trajs/utils.hpp>
 
 namespace inria_wbc {
     namespace behaviors {
@@ -30,76 +31,6 @@ namespace inria_wbc {
                 state_ = States::INIT;
                 time_ = 0;
                 _generate_trajectories();
-            }
-
-            std::vector<tsid::trajectories::TrajectorySample> WalkOnSpot::_to_sample_trajectory(
-                const std::vector<pinocchio::SE3>& traj) const
-            {
-                Eigen::VectorXd pos_vec(12);
-                std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
-                for(int i=0; i < traj.size(); ++i)
-                {
-                    tsid::math::SE3ToVector(traj[i], pos_vec);
-                    tsid::trajectories::TrajectorySample sample(12,6);
-                    sample.setValue(pos_vec);
-                    sample_trajectory.push_back(sample);
-                }
-                return sample_trajectory;
-            }
-
-            std::vector<tsid::trajectories::TrajectorySample> WalkOnSpot::_to_sample_trajectory(
-                const std::vector<pinocchio::SE3>& traj, const std::vector<Eigen::VectorXd>& vels, 
-                const std::vector<Eigen::VectorXd>& accs) const
-            {
-                Eigen::VectorXd pos_vec(12);
-                std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
-                for(int i=0; i < traj.size(); ++i)
-                {
-                    tsid::math::SE3ToVector(traj[i], pos_vec);
-
-                    tsid::trajectories::TrajectorySample sample(12,6);
-                    sample.setValue(pos_vec);
-                    sample.setDerivative(vels[i]);
-                    sample.setSecondDerivative(accs[i]);
-
-                    sample_trajectory.push_back(sample);
-                }
-
-                return sample_trajectory;
-            }
-
-            std::vector<tsid::trajectories::TrajectorySample> WalkOnSpot::_to_sample_trajectory(
-                const std::vector<Eigen::VectorXd>& traj) const
-            {
-                size_t dofs = traj[0].size();
-                std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
-                for(int i=0; i < traj.size(); ++i)
-                {
-                    tsid::trajectories::TrajectorySample sample(dofs, dofs);
-                    sample.setValue(traj[i]);
-                    sample_trajectory.push_back(sample);
-                }
-                return sample_trajectory;
-            }
-
-            std::vector<tsid::trajectories::TrajectorySample> WalkOnSpot::_to_sample_trajectory(
-                const std::vector<Eigen::VectorXd>& traj, const std::vector<Eigen::VectorXd>& vels, 
-                const std::vector<Eigen::VectorXd>& accs) const
-            {
-                size_t dofs = traj[0].size();
-
-                std::vector<tsid::trajectories::TrajectorySample> sample_trajectory;
-                for(int i=0; i < traj.size(); ++i)
-                {
-                    tsid::trajectories::TrajectorySample sample(dofs, dofs);
-                    sample.setValue(traj[i]);
-                    sample.setDerivative(vels[i]);
-                    sample.setSecondDerivative(accs[i]);
-
-                    sample_trajectory.push_back(sample);
-                }
-
-                return sample_trajectory;
             }
 
             void WalkOnSpot::_generate_trajectories()
@@ -141,10 +72,10 @@ namespace inria_wbc {
                 for (auto c : cycle_) {
                     switch (c) {
                     case States::INIT:
-                        _rf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
-                        _lf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
+                        _rf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
+                        _lf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
                         _com_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(com_init, com_rf, dt_, traj_com_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(com_init, com_rf, dt_, traj_com_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(com_init, com_rf, dt_, traj_com_duration_)
@@ -152,32 +83,32 @@ namespace inria_wbc {
                         );
                         break;
                     case States::LIFT_UP_LF:
-                        _rf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_foot_duration_)));
+                        _rf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_foot_duration_)));
                         _lf_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(lf_low, lf_high, dt_, traj_foot_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(lf_low, lf_high, dt_, traj_foot_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(lf_low, lf_high, dt_, traj_foot_duration_)
                             */)
                         );
-                        _com_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(com_rf, dt_, traj_foot_duration_)));
+                        _com_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(com_rf, dt_, traj_foot_duration_)));
                         break;
                     case States::LIFT_DOWN_LF:
-                        _rf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_foot_duration_)));
+                        _rf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_foot_duration_)));
                         _lf_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(lf_high, lf_low, dt_, traj_foot_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(lf_high, lf_low, dt_, traj_foot_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(lf_high, lf_low, dt_, traj_foot_duration_)
                             */)
                         );
-                        _com_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(com_rf, dt_, traj_foot_duration_)));
+                        _com_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(com_rf, dt_, traj_foot_duration_)));
                         break;
                     case States::MOVE_COM_LEFT:
-                        _rf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
-                        _lf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
+                        _rf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
+                        _lf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
                         _com_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(com_rf, com_lf, dt_, traj_com_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(com_rf, com_lf, dt_, traj_com_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(com_rf, com_lf, dt_, traj_com_duration_)
@@ -186,31 +117,31 @@ namespace inria_wbc {
                         break;
                     case States::LIFT_UP_RF:
                         _rf_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(rf_low, rf_high, dt_, traj_foot_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(rf_low, rf_high, dt_, traj_foot_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(rf_low, rf_high, dt_, traj_foot_duration_)
                             */)
                         );
-                        _lf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_foot_duration_)));
-                        _com_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(com_lf, dt_, traj_foot_duration_)));
+                        _lf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_foot_duration_)));
+                        _com_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(com_lf, dt_, traj_foot_duration_)));
                         break;
                     case States::LIFT_DOWN_RF:
                         _rf_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(rf_high, rf_low, dt_, traj_foot_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(rf_high, rf_low, dt_, traj_foot_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(rf_high, rf_low, dt_, traj_foot_duration_)
                             */)
                         );
-                        _lf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_foot_duration_)));
-                        _com_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(com_lf, dt_, traj_foot_duration_)));
+                        _lf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_foot_duration_)));
+                        _com_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(com_lf, dt_, traj_foot_duration_)));
                         break;
                     case States::MOVE_COM_RIGHT:
-                        _rf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
-                        _lf_trajs.push_back(_to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
+                        _rf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(rf_low, dt_, traj_com_duration_)));
+                        _lf_trajs.push_back(trajs::to_sample_trajectory(trajs::constant_traj(lf_low, dt_, traj_com_duration_)));
                         _com_trajs.push_back(
-                            _to_sample_trajectory(
+                            trajs::to_sample_trajectory(
                                 trajs::min_jerk_trajectory(com_lf, com_rf, dt_, traj_com_duration_)/*,
                                 trajs::min_jerk_trajectory<trajs::d_order::FIRST>(com_lf, com_rf, dt_, traj_com_duration_),
                                 trajs::min_jerk_trajectory<trajs::d_order::SECOND>(com_lf, com_rf, dt_, traj_com_duration_)
@@ -224,14 +155,6 @@ namespace inria_wbc {
                 assert(_rf_trajs.size() == cycle_.size());
                 assert(_lf_trajs.size() == cycle_.size());
                 assert(_com_trajs.size() == cycle_.size());
-            }
-
-            pinocchio::SE3 WalkOnSpot::se3_from_sample(const tsid::trajectories::TrajectorySample& sample) const
-            {
-                pinocchio::SE3 se3;
-                se3.translation() = sample.getValue().head<3>();
-                se3.rotation() = Eigen::Matrix3d::Map(sample.getValue().data()+3);
-                return se3;
             }
 
             void WalkOnSpot::update(const controllers::SensorData& sensor_data)
@@ -264,8 +187,8 @@ namespace inria_wbc {
                 assert(time_ < _rf_trajs[_current_traj].size());
                 assert(time_ < _lf_trajs[_current_traj].size());
 
-                pinocchio::SE3 lf_se3 = se3_from_sample(_lf_trajs[_current_traj][time_]);
-                pinocchio::SE3 rf_se3 = se3_from_sample(_rf_trajs[_current_traj][time_]);
+                pinocchio::SE3 lf_se3 = trajs::se3_from_sample(_lf_trajs[_current_traj][time_]);
+                pinocchio::SE3 rf_se3 = trajs::se3_from_sample(_rf_trajs[_current_traj][time_]);
 
                 controller->set_com_ref(_com_trajs[_current_traj][time_]);
                 controller->set_se3_ref(_lf_trajs[_current_traj][time_], "lf");

--- a/src/behaviors/humanoid/walk_on_spot.cpp
+++ b/src/behaviors/humanoid/walk_on_spot.cpp
@@ -71,39 +71,39 @@ namespace inria_wbc {
                 for (auto c : cycle_) {
                     switch (c) {
                     case States::INIT:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_init, com_rf, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_init, com_rf, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_UP_LF:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_low, lf_high, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_low, lf_high, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
                         break;
                     case States::LIFT_DOWN_LF:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::compute_traj(lf_high, lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_rf, dt_, traj_foot_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::min_jerk_trajectory(lf_high, lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_rf, dt_, traj_foot_duration_));
                         break;
                     case States::MOVE_COM_LEFT:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_rf, com_lf, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_rf, com_lf, dt_, traj_com_duration_));
                         break;
                     case States::LIFT_UP_RF:
-                        _rf_trajs.push_back(trajectory_handler::compute_traj(rf_low, rf_high, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_lf, dt_, traj_foot_duration_));
+                        _rf_trajs.push_back(trajs::min_jerk_trajectory(rf_low, rf_high, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_lf, dt_, traj_foot_duration_));
                         break;
                     case States::LIFT_DOWN_RF:
-                        _rf_trajs.push_back(trajectory_handler::compute_traj(rf_high, rf_low, dt_, traj_foot_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_foot_duration_));
-                        _com_trajs.push_back(trajectory_handler::constant_traj(com_lf, dt_, traj_foot_duration_));
+                        _rf_trajs.push_back(trajs::min_jerk_trajectory(rf_high, rf_low, dt_, traj_foot_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_foot_duration_));
+                        _com_trajs.push_back(trajs::constant_traj(com_lf, dt_, traj_foot_duration_));
                         break;
                     case States::MOVE_COM_RIGHT:
-                        _rf_trajs.push_back(trajectory_handler::constant_traj(rf_low, dt_, traj_com_duration_));
-                        _lf_trajs.push_back(trajectory_handler::constant_traj(lf_low, dt_, traj_com_duration_));
-                        _com_trajs.push_back(trajectory_handler::compute_traj(com_lf, com_rf, dt_, traj_com_duration_));
+                        _rf_trajs.push_back(trajs::constant_traj(rf_low, dt_, traj_com_duration_));
+                        _lf_trajs.push_back(trajs::constant_traj(lf_low, dt_, traj_com_duration_));
+                        _com_trajs.push_back(trajs::min_jerk_trajectory(com_lf, com_rf, dt_, traj_com_duration_));
                         break;
                     default:
                         assert(0 && "unknown state");

--- a/src/controllers/pos_tracker.cpp
+++ b/src/controllers/pos_tracker.cpp
@@ -23,6 +23,7 @@
 
 #include "inria_wbc/controllers/pos_tracker.hpp"
 #include "inria_wbc/controllers/tasks.hpp"
+#include "inria_wbc/trajs/utils.hpp"
 
 using namespace tsid;
 using namespace tsid::math;
@@ -159,14 +160,14 @@ namespace inria_wbc {
         void PosTracker::set_se3_ref(const pinocchio::SE3& ref, const std::string& task_name)
         {
             auto task = se3_task(task_name);
-            auto sample = to_sample(ref);
+            auto sample = trajs::to_sample(ref);
             task->setReference(sample);
         }
 
         void PosTracker::set_contact_se3_ref(const pinocchio::SE3& ref, const std::string& contact_name)
         {
             auto c = contact(contact_name);
-            auto sample = to_sample(ref);
+            auto sample = trajs::to_sample(ref);
             c->setReference(sample);
         }
 

--- a/src/controllers/tasks.cpp
+++ b/src/controllers/tasks.cpp
@@ -9,6 +9,7 @@
 #include <tsid/tasks/task-se3-equality.hpp>
 
 #include "inria_wbc/controllers/tasks.hpp"
+#include "inria_wbc/trajs/utils.hpp"
 #include "tsid/tasks/task-self-collision.hpp"
 
 using namespace tsid;
@@ -71,7 +72,7 @@ namespace inria_wbc {
                 ref = robot->position(tsid->data(), robot->model().getJointId(tracked));
             else
                 ref = robot->framePosition(tsid->data(), robot->model().getFrameId(tracked));
-            auto sample = to_sample(ref);
+            auto sample = trajs::to_sample(ref);
             task->setReference(sample);
 
             // add the task to TSID (side effect, be careful)
@@ -106,7 +107,7 @@ namespace inria_wbc {
             task->setMask(mask);
 
             // set the reference
-            task->setReference(to_sample(robot->com(tsid->data())));
+            task->setReference(trajs::to_sample(robot->com(tsid->data())));
 
             // add to TSID
             tsid->addMotionTask(*task, weight, 1);
@@ -141,7 +142,7 @@ namespace inria_wbc {
 
             // set the reference
             Eigen::VectorXd ref = Eigen::VectorXd::Zero(6);
-            task->setReference(to_sample(ref));
+            task->setReference(trajs::to_sample(ref));
 
             // add to TSID
             tsid->addMotionTask(*task, weight, 1);
@@ -212,7 +213,7 @@ namespace inria_wbc {
             task->setMask(mask_post);
 
             // set the reference to the current position of the robot
-            task->setReference(to_sample(ref_q.tail(robot->na())));
+            task->setReference(trajs::to_sample(ref_q.tail(robot->na())));
 
             // add the task
             tsid->addMotionTask(*task, weight, 1);


### PR DESCRIPTION
Add velocity and acceleration profile for trajectory generation
Trajectory orientation generation is changed from quaternion slerp to angleaxis rotation between start and end frame

```C++
namespace th = trajectory_handler;

compute_traj(start_vec, end_vec, dt, duration) // se3 trajectory -> std::vector<Vec>
compute_traj<th::order::ZERO>(start_vec, end_vec, dt, duration) // se3 trajectory -> std::vector<Vec>
compute_traj<th::order::FIRST>(start_vec, end_vec, dt, duration) // se3 trajectory velocity  -> std::vector<Vec>
compute_traj<th::order::SECOND>(start_vec, end_vec, dt, duration) // se3 trajectory acceleration -> std::vector<Vec>

compute_traj(start_se3, end_se3, dt, duration) // se3 trajectory -> std::vector<SE3>
compute_traj<th::order::FIRST>(start_se3, end_se3, dt, duration) // se3 trajectory velocity  -> std::vector<Vec6>
compute_traj<th::order::SECOND>(start_se3, end_se3, dt, duration) // se3 trajectory acceleration -> std::vector<Vec6>
```

Changes to generic cartesian behavior:
 - now accept change in orientation.
 - add velocity and acceleration profile in tsid task references