### PR TITLE
Add support for utheque when loading the URDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(COMPILE_ROBOT_DART_EXAMPLE_GRAPHICS "compile robot-dart example with grap
 find_package(tsid REQUIRED)
 find_package(pinocchio REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(Utheque)
 find_package(Boost OPTIONAL_COMPONENTS stacktrace_basic)
 
 
@@ -43,11 +44,15 @@ IF(APPLE)
 endif()
 target_compile_features(inria_wbc PUBLIC cxx_std_14)
 
+if (Utheque_FOUND)
+  target_compile_definitions(inria_wbc PUBLIC WBC_HAS_UTHEQUE)
+endif()
 
 target_link_libraries(inria_wbc PUBLIC 
 			pinocchio::pinocchio
 			tsid::tsid
-			${YAML_CPP_LIBRARIES})
+			${YAML_CPP_LIBRARIES}
+      Utheque)
 
 if(Boost_stacktrace_basic_FOUND)
   target_compile_definitions(inria_wbc PUBLIC IWBC_USE_STACKTRACE=1 BOOST_STACKTRACE_DYN_LINK=1) #force to not use header library but shared

--- a/etc/talos/talos_pos_tracker.yaml
+++ b/etc/talos/talos_pos_tracker.yaml
@@ -2,7 +2,7 @@ CONTROLLER:
   name: talos-pos-tracker
   base_path: /home/pal/inria_wbc/etc/talos
   tasks: tasks.yaml
-  urdf: talos.urdf
+  urdf: talos/talos.urdf
   configurations: configurations.srdf 
   ref_config: inria_start
   frames: frames.yaml

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -37,6 +37,11 @@
 #include <tsid/utils/statistics.hpp>
 #include <tsid/utils/stop-watch.hpp>
 
+#ifdef WBC_HAS_UTHEQUE
+// easy search for an URDF
+#include <utheque/utheque.hpp>
+#endif
+
 #include "inria_wbc/controllers/controller.hpp"
 #include "inria_wbc/exceptions.hpp"
 
@@ -63,7 +68,12 @@ namespace inria_wbc {
             base_path_ = IWBC_CHECK(c["base_path"].as<std::string>());
             auto floating_base_joint_name = IWBC_CHECK(c["floating_base_joint_name"].as<std::string>());
             auto urdf = IWBC_CHECK(c["urdf"].as<std::string>());
+#ifdef WBC_HAS_UTHEQUE
+            urdf_ = utheque::path(urdf);
+#else
             urdf_ = urdf;
+            #warning Utheque (URDF library) not found during cmake configuration
+#endif
             dt_ = IWBC_CHECK(c["dt"].as<double>());
             mimic_dof_names_ = IWBC_CHECK(c["mimic_dof_names"].as<std::vector<std::string>>());
             verbose_ = IWBC_CHECK(c["verbose"].as<bool>());


### PR DESCRIPTION
- The support is optional 
- No additional runtime dependency (since utheque is header only)
- This will search the URDF from the YAML file in the  utheque paths