### PR TITLE
add actuation bounds creation from tasks.yaml file

### DIFF
--- a/etc/talos/tasks.yaml
+++ b/etc/talos/tasks.yaml
@@ -26,7 +26,7 @@ rf:
     type: se3
     tracked: leg_right_6_joint
     weight: 1000.0
-    kp: 30.0     
+    kp: 30.0
     mask: 111111
 com:
     type: com
@@ -76,11 +76,11 @@ self_collision-left:
     type: self-collision
     tracked: gripper_left_joint
     radius: 0.1
-    avoided: 
+    avoided:
         gripper_right_joint: 0.1
         arm_right_5_joint: 0.05
         v_leg_right_3: 0.15
-        v_leg_left_3: 0.15        
+        v_leg_left_3: 0.15
         torso_2_joint: 0.1
         base_link: 0.15
         v_base_link_left: 0.115
@@ -96,11 +96,11 @@ self_collision-right:
     type: self-collision
     tracked: gripper_right_joint
     radius: 0.1
-    avoided: 
+    avoided:
         gripper_left_joint: 0.1
         arm_left_5_joint: 0.05
         v_leg_right_3: 0.15
-        v_leg_left_3: 0.15        
+        v_leg_left_3: 0.15
         torso_2_joint: 0.1
         base_link: 0.15
         v_base_link_left: 0.115

--- a/src/controllers/tasks.cpp
+++ b/src/controllers/tasks.cpp
@@ -251,6 +251,31 @@ namespace inria_wbc {
         }
         RegisterYAML<tsid::tasks::TaskJointPosVelAccBounds> __register_bounds("bounds", make_bounds);
 
+        ////// Actuation Bounds //////
+        std::shared_ptr<tsid::tasks::TaskBase> make_actuationbounds(
+            const std::shared_ptr<robots::RobotWrapper>& robot,
+            const std::shared_ptr<InverseDynamicsFormulationAccForce>& tsid,
+            const std::string& task_name, const YAML::Node& node, const YAML::Node& controller_node)
+        {
+            assert(tsid);
+            assert(robot);
+
+            // parse yaml
+            auto weight = IWBC_CHECK(node["weight"].as<double>());
+
+            // create the task
+            auto task = std::make_shared<tsid::tasks::TaskActuationBounds>(task_name, *robot);
+            auto tau_max = robot->model().effortLimit.tail(robot->na());
+            task->setBounds(-tau_max, tau_max);
+
+            // add the task
+            tsid->addActuationTask(*task, weight, 0);
+
+            return task;
+        }
+        RegisterYAML<tsid::tasks::TaskActuationBounds> __register_actuationbounds("actuationbounds", make_actuationbounds);
+
+
         ////// Contacts //////
         /// this looks like a task, but this does not derive from tsid::task::TaskBase
         std::shared_ptr<tsid::contacts::Contact6dExt> make_contact_task(


### PR DESCRIPTION
Added code in inria_wbc/controller/task.cpp to create actuation bounds from task.yaml file.
NB: does not handle "double" acceleration limits definition between actuation_bounds and posvelacc_bounds, so if using both kinds of bounds, there is two definitions for the acceleration limits. But this is handled in the QP, and examples do work.