### PR TITLE
Fix utheque

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(COMPILE_ROBOT_DART_EXAMPLE_GRAPHICS "compile robot-dart example with grap
 find_package(tsid REQUIRED)
 find_package(pinocchio REQUIRED)
 find_package(yaml-cpp REQUIRED)
-find_package(Utheque)
+find_package(Utheque) # optional
 find_package(Boost OPTIONAL_COMPONENTS stacktrace_basic)
 
 
@@ -46,13 +46,14 @@ target_compile_features(inria_wbc PUBLIC cxx_std_14)
 
 if (Utheque_FOUND)
   target_compile_definitions(inria_wbc PUBLIC WBC_HAS_UTHEQUE)
+  set(UTHEQUE_LIB Utheque)
 endif()
 
 target_link_libraries(inria_wbc PUBLIC 
 			pinocchio::pinocchio
 			tsid::tsid
 			${YAML_CPP_LIBRARIES}
-      Utheque)
+      ${UTHEQUE_LIB})
 
 if(Boost_stacktrace_basic_FOUND)
   target_compile_definitions(inria_wbc PUBLIC IWBC_USE_STACKTRACE=1 BOOST_STACKTRACE_DYN_LINK=1) #force to not use header library but shared


### PR DESCRIPTION
When the lib was not found, we were still doing:
```cmake

target_link_libraries(inria_wbc PUBLIC 
			pinocchio::pinocchio
			tsid::tsid
			${YAML_CPP_LIBRARIES}
                        Utheque)
```
... and we were assuming that Utheque was empty as this was not found. This was added 'to be clean' because this is a header-only library anyway.

However, when `cmake` does not find a library, it tries to link with it using `-lUtheque`. We were therefore trying to link with a non-existent library (header-only) when it was not found (and therefore not recognized as a header-only library).

This should be fixed now. 



