### PR TITLE
fix boost::mpl list/vector limits needed by pinocchio

### DIFF
--- a/src/robot_dart/franka.cpp
+++ b/src/robot_dart/franka.cpp
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -21,6 +20,8 @@
 #include "inria_wbc/exceptions.hpp"
 #include "inria_wbc/robot_dart/cmd.hpp"
 #include "inria_wbc/utils/timer.hpp"
+
+#include <boost/program_options.hpp> // Boost need to be always included after pinocchio & inria_wbc
 
 int main(int argc, char* argv[])
 {

--- a/src/robot_dart/icub.cpp
+++ b/src/robot_dart/icub.cpp
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -31,6 +30,8 @@
 #include "inria_wbc/trajs/saver.hpp"
 #include "inria_wbc/utils/timer.hpp"
 #include "tsid/tasks/task-self-collision.hpp"
+
+#include <boost/program_options.hpp> // Boost need to be always included after pinocchio & inria_wbc
 
 static const std::string red = "\x1B[31m";
 static const std::string rst = "\x1B[0m";

--- a/src/robot_dart/talos_load_external.cpp
+++ b/src/robot_dart/talos_load_external.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -31,6 +30,8 @@
 #include "inria_wbc/trajs/saver.hpp"
 #include "inria_wbc/utils/timer.hpp"
 #include "tsid/tasks/task-self-collision.hpp"
+
+#include <boost/program_options.hpp> // Boost need to be always included after pinocchio & inria_wbc
 
 static const std::string red = "\x1B[31m";
 static const std::string rst = "\x1B[0m";

--- a/src/robot_dart/tiago.cpp
+++ b/src/robot_dart/tiago.cpp
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -24,6 +23,8 @@
 #include "inria_wbc/robot_dart/self_collision_detector.hpp"
 #include "inria_wbc/robot_dart/utils.hpp"
 #include "tsid/tasks/task-self-collision.hpp"
+
+#include <boost/program_options.hpp> // Boost need to be always included after pinocchio & inria_wbc
 
 int main(int argc, char* argv[])
 {

--- a/tests/test_all_robots.cpp
+++ b/tests/test_all_robots.cpp
@@ -5,9 +5,6 @@
 #include <stdio.h>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
-
 #include <robot_dart/robot_dart_simu.hpp>
 #include <robot_dart/robots/franka.hpp>
 #include <robot_dart/robots/icub.hpp>
@@ -27,6 +24,9 @@
 #include "inria_wbc/robot_dart/self_collision_detector.hpp"
 #include "inria_wbc/robot_dart/utils.hpp"
 #include "inria_wbc/utils/timer.hpp"
+
+#include <boost/filesystem.hpp> // Boost need to be always included after pinocchio & inria_wbc
+#include <boost/program_options.hpp>
 
 #include "utest.hpp"
 


### PR DESCRIPTION
Pinocchio needs to setup some boost magic to ensure mpl::list and mpl::vector can hold more than their default 20 arguments. Including any boost header before that will prevent this configuration to happen, and compilation fails.

This PR moves all boost includes after pinocchio/tsid. It was already done in src/robot_dart/talos.cpp, I've just made a similar arrangement in all affected files.

Other options:
- pinocchio defines and exports some limits in its CMakeLists.txt, but without another define (BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS) this has no effect. Instead of changing the order of inclusion, we could add `target_compile_definitions(inria_wbc PUBLIC BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS=1)` on our side, but this means having half of the fix in pinocchio, half here :disappointed:  and this would break if pinocchio removes or changes this in its cmakelists. This would however ensure that any new code in inria_wbc would also be protected against that bug.
- adding the missing ` BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS` in pinocchio directly seems to break things in python and was rejected.
- as nobody likes this boost-config-by-global-defines thing, the requirement in pinocchio will hopefully disappear at some point anyway (using other c++ techniques instead of the good old mpl possibly...)