### PR TITLE
Fix com_admittance stabilizer

### DIFF
--- a/include/inria_wbc/stabilizers/stabilizer.hpp
+++ b/include/inria_wbc/stabilizers/stabilizer.hpp
@@ -44,6 +44,7 @@ namespace inria_wbc {
         void com_admittance(
             double dt, // controller dt
             const Eigen::VectorXd& p, // 6d proportional gains
+            const Eigen::Vector2d& forward, // x vector in a pure yaw rotation of the robot in world frame
             const Eigen::Vector2d& cop_filtered, //filtered cop estimation
             const tsid::trajectories::TrajectorySample& model_current_com, //pinocchio current com pos,vel,acc
             const tsid::trajectories::TrajectorySample& com_ref, //next com reference

--- a/src/controllers/humanoid_pos_tracker.cpp
+++ b/src/controllers/humanoid_pos_tracker.cpp
@@ -221,7 +221,8 @@ namespace inria_wbc {
                 const auto& valid_cop = cops[0] ? cops[0] : (cops[1] ? cops[1] : cops[2]);
                 // com_admittance
                 if (valid_cop) {
-                    stabilizer::com_admittance(dt_, _stabilizer_configs[behavior_type_].com_gains, valid_cop.value(), model_current_com, com_ref, com_sample);
+                    Eigen::Vector2d forward = Eigen::Quaterniond(this->q_tsid().segment<4>(3)).toRotationMatrix().col(0).head<2>().normalized();
+                    stabilizer::com_admittance(dt_, _stabilizer_configs[behavior_type_].com_gains, forward, valid_cop.value(), model_current_com, com_ref, com_sample);
                     set_com_ref(com_sample);
                     _stabilizer_samples["com"] = com_sample;
                 }


### PR DESCRIPTION
This PR correct the behavior of com admittance once the robot is rotated about z-axis world axis. Related to issue #122.

Cop error is now rotated in robot frame and gains are then applied. Finally the correction of the com is bring back in world frame.